### PR TITLE
transceiver: client: Keep connection alive

### DIFF
--- a/examples/collect_files/main.py
+++ b/examples/collect_files/main.py
@@ -61,11 +61,6 @@ async def connect_node(transceiver, output_dir, addr):
     finally:
         logger.info("Exiting task for node %s", addr)
 
-async def ping_loop(transceiver):
-    while True:
-        await transceiver.ping()
-        await asyncio.sleep(1.0)
-
 async def connect_transceiver(host, output_dir):
     async with TransceiverClient(host) as transceiver:
         logger.info(f"Connected to transceiver at {host}")
@@ -74,8 +69,6 @@ async def connect_transceiver(host, output_dir):
         logger.info(f"Updated time in transceiver {host}")
 
         async with asyncio.TaskGroup() as tg:
-            tg.create_task(ping_loop(transceiver))
-
             connected_nodes_resp = await transceiver.get_connected_nodes()
             for node in connected_nodes_resp.nodes:
                 tg.create_task(connect_node(transceiver, output_dir, node.address))

--- a/examples/forwarder/forwarder.py
+++ b/examples/forwarder/forwarder.py
@@ -82,15 +82,7 @@ class AnuraSupervisor:
                     transceiver_config["host"]
                 )
 
-                async def _ping_task():
-                    # "Ping" periodically to keep the connection alive.
-                    while True:
-                        await asyncio.wait_for(transceiver.ping(), 1.0)
-                        await asyncio.sleep(2.0)
-
                 async with asyncio.TaskGroup() as tg:
-                    tg.create_task(_ping_task())
-
                     if self.on_transceiver_connect:
                         await self.on_transceiver_connect(transceiver)
 


### PR DESCRIPTION
* Make TransceiverClient keep the connection alive in a background task.

* Modify CLI and examples, removing keep-alive tasks that are no longer needed.