### PR TITLE
transceiver: Implement get_firmware_info RPC method

### DIFF
--- a/anura/cli/transceiver_commands.py
+++ b/anura/cli/transceiver_commands.py
@@ -103,6 +103,12 @@ async def get_device_status(client: TransceiverClient):
 
 @transceiver_group.command()
 @with_transceiver_client
+async def get_firmware_info(client: TransceiverClient):
+    """Get firmware info."""
+    click.echo(await client.get_firmware_info())
+
+@transceiver_group.command()
+@with_transceiver_client
 async def get_ptp_status(client: TransceiverClient):
     """Get Precision Time Protocol (PTP) status."""
     click.echo(await client.get_ptp_status())

--- a/anura/transceiver/client.py
+++ b/anura/transceiver/client.py
@@ -229,6 +229,9 @@ class TransceiverClient:
     async def get_device_status(self) -> GetDeviceStatusResult:
         return await self.request("get_device_status", result_type=GetDeviceStatusResult)
 
+    async def get_firmware_info(self) -> GetFirmwareInfoResult:
+        return await self.request("get_firmware_info", result_type=GetFirmwareInfoResult)
+
     async def get_ptp_status(self) -> GetPtpStatusResult:
         return await self.request("get_ptp_status", result_type=GetPtpStatusResult)
 

--- a/anura/transceiver/models.py
+++ b/anura/transceiver/models.py
@@ -138,6 +138,16 @@ class GetDeviceStatusResult():
 
 @dataclass_cbor()
 @dataclass
+class GetFirmwareInfoResult:
+    dfu_status: int = field(0)
+    app_version: int = field(1)
+    app_build_version: int = field(2)
+    net_version: int = field(3)
+    net_build_version: int = field(4)
+
+
+@dataclass_cbor()
+@dataclass
 class GetPtpStatusResult():
     port_state: str = field(0)
     offset: str = field(1)


### PR DESCRIPTION
* Add support for the get_firmware_info command in the TransceiverClient class.

* Add a CLI command "anura transceiver get-firmware-info" using the new RPC method.