### PR TITLE
Allow subscribing to raw reports() 

### DIFF
--- a/anura/avss/client.py
+++ b/anura/avss/client.py
@@ -14,9 +14,18 @@ from typing import (
     Callable,
     Generator,
     Optional,
+    TypeAlias,
 )
 
 logger = logging.getLogger(__name__)
+
+_ParsedReport: TypeAlias = (
+    AggregatedValuesReport
+    | CaptureReport
+    | HealthReport
+    | SettingsReport
+    | SnippetReport
+)
 
 class AVSSError(Exception):
     pass
@@ -163,9 +172,11 @@ class AVSSClient:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
-    def _callback_and_generator(self, parse) -> tuple[Callable[[Report], None], AsyncGenerator[Report, None]]:
+    def _callback_and_generator(
+        self, parse: bool
+    ) -> tuple[Callable[[Report], None], AsyncGenerator[Report | _ParsedReport, None]]:
         # Queue to hold the incoming reports
-        reports: asyncio.Queue[Report] = asyncio.Queue()
+        reports: asyncio.Queue[Report | _ParsedReport] = asyncio.Queue()
 
         def _callback(msg: Report) -> None:
             """Put the new Report in the queue."""
@@ -177,7 +188,7 @@ class AVSSClient:
             except asyncio.QueueFull:
                 logger.warning("Report queue is full. Discarding message.")
 
-        async def _generator() -> AsyncGenerator[Report, None]:
+        async def _generator() -> AsyncGenerator[Report | _ParsedReport, None]:
             """Forward all Reports from the report queue."""
             while True:
                 # Wait until we either:
@@ -206,7 +217,7 @@ class AVSSClient:
         return _callback, _generator()
 
     @contextmanager
-    def reports(self, parse=True) -> Generator[AsyncGenerator[Report, None], None, None]:
+    def reports(self, parse=True) -> Generator[AsyncGenerator[Report | _ParsedReport, None], None, None]:
         """Context manager that creates a queue for incoming Reports.
 
         Returns:

--- a/anura/avss/client.py
+++ b/anura/avss/client.py
@@ -79,6 +79,13 @@ ResponseCode.OpCodeUnsupported = 3
 ResponseCode.Busy = 4
 ResponseCode.BadArgument = 5
 
+ReportType = types.SimpleNamespace()
+ReportType.Snippet = 2
+ReportType.AggregatedValues = 3
+ReportType.Health = 4
+ReportType.Settings = 5
+ReportType.Capture = 6
+
 SEGMENT_FIRST = 0x80
 SEGMENT_LAST = 0x40
 SEGMENT_NUMBER_MASK = 0x3F
@@ -106,11 +113,11 @@ class Report:
 
     def parse(self):
         report_classes = {
-            2: SnippetReport,
-            3: AggregatedValuesReport,
-            4: HealthReport,
-            5: SettingsReport,
-            6: CaptureReport,
+            ReportType.Snippet: SnippetReport,
+            ReportType.AggregatedValues: AggregatedValuesReport,
+            ReportType.Health: HealthReport,
+            ReportType.Settings: SettingsReport,
+            ReportType.Capture: CaptureReport,
         }
         if report_class := report_classes.get(self.report_type):
             return report_class.from_cbor(self.payload_cbor)

--- a/anura/avss/models.py
+++ b/anura/avss/models.py
@@ -70,31 +70,9 @@ class GetVersionResponse:
     version: str = field(0)
     build_version: str = field(1)
 
-class Report:
-    def parse(record):
-        report_type = record[0]
-        payload = record[1:]
-
-        report_classes = {
-            2: SnippetReport,
-            3: AggregatedValuesReport,
-            4: HealthReport,
-            5: SettingsReport,
-            6: CaptureReport,
-        }
-        if report_class := report_classes.get(report_type):
-            return report_class.from_cbor(payload)
-        else:
-            return UnknownReport(report_type, payload)
-
-class UnknownReport(Report):
-    def __init__(self, report_type, payload):
-        self.report_type = report_type
-        self.payload = payload
-
 @dataclass_cbor()
 @dataclass
-class SnippetReport(Report):
+class SnippetReport:
     start_time: int = field(0)
     sample_rate: int = field(1)
     range_: int = field(2)
@@ -103,7 +81,7 @@ class SnippetReport(Report):
 
 @dataclass_cbor()
 @dataclass
-class CaptureReport(Report):
+class CaptureReport:
     start_time: int = field(0)
     end_time: int = field(1)
     range_: int = field(2)
@@ -111,14 +89,14 @@ class CaptureReport(Report):
 
 @dataclass_cbor()
 @dataclass
-class AggregatedValuesReport(Report):
+class AggregatedValuesReport:
     start_time: int = field(0)
     duration: int = field(1)
     values: dict[int, int] = field(2)
 
 @dataclass_cbor()
 @dataclass
-class HealthReport(Report):
+class HealthReport:
     uptime: int = field(0)
     reboot_count: int = field(1)
     reset_cause: int = field(2)
@@ -132,5 +110,5 @@ class HealthReport(Report):
 
 @dataclass_cbor()
 @dataclass
-class SettingsReport(Report):
+class SettingsReport:
     settings: dict = field(0)

--- a/anura/cli/avss_commands.py
+++ b/anura/cli/avss_commands.py
@@ -112,7 +112,9 @@ async def reset(client: avss.AVSSClient):
 @with_avss_client
 async def throughput(client: avss.AVSSClient, duration: float):
     """Perform a throughput test."""
-    with client.reports() as reports:
+    # Passing parse=False lets us access the raw payload and, more importantly,
+    # it lets us access the transfer info.
+    with client.reports(parse=False) as reports:
         click.echo(f"Starting {duration} s throughput test...")
         await client.test_throughput(duration=duration*1000)
         test = await anext(reports)


### PR DESCRIPTION
Message copied from the principal commit:
```
avss: Allow subscribing to raw reports()

* Modified AVSSClient.reports() to take a "parse" parameter.
If passed as True (default) the returned async generator
yields parsed AVSS report classes (e.g. SnippetReport).
If passed as False the generator yields objects of class
Report containing the raw record gotten by concatenating
report segments.
```