### PR TITLE
cli: Add support for snippets to avss-throughput command

### DIFF
--- a/anura/cli/transceiver_commands.py
+++ b/anura/cli/transceiver_commands.py
@@ -92,14 +92,75 @@ async def get_connected_nodes(client: TransceiverClient):
 
 @transceiver_group.command()
 @with_transceiver_client
-@click.option("--duration", default=1)
-async def avss_throughput(client: TransceiverClient, duration: int):
+@click.option(
+    "--test-data",
+    "mode",
+    flag_value="test",
+    default=True,
+    help="Measure transfer speed using artifical test data.",
+)
+@click.option(
+    "--snippet-reports",
+    "mode",
+    flag_value="snippets",
+    help="Measure transfer speed for snippet reports.",
+)
+@click.option(
+    "--duration", default=1, help="Duration of artificial test data. Use with '--test'."
+)
+async def avss_throughput(client: TransceiverClient, mode: str, duration: int):
     """Measure concurrent AVSS throughput."""
 
     async def test_throughput(addr):
         async with ProxyAVSSClient(client, addr) as node:
             with node.reports(parse=False) as reports:
-                click.echo(f"{addr}: Starting {duration} s throughput test...")
+                if mode == "test":
+                    click.echo(f"{addr}: Starting {duration} s throughput test...")
+                    await node.test_throughput(duration=duration*1000)
+                elif mode == "snippets":
+                    click.echo(f"{addr}: Requesting snippet reports...")
+                    await node.report_snippets(count=None, auto_resume=True)
+
+                async for test in reports:
+                    if test.transfer_info.elapsed_time > 0:
+                        throughput = (
+                            test.transfer_info.num_bytes / test.transfer_info.elapsed_time / 1000
+                        )
+                    else:
+                        throughput = "??"
+
+                    click.echo(f"{addr}: Received {test.transfer_info.num_bytes} B "
+                            f"over {test.transfer_info.num_segments} segments "
+                            f"in {test.transfer_info.elapsed_time:.2f} s "
+                            f"({throughput:.2f} kB/s)")
+
+                    if mode == "test":
+                        # Only one test report is generated per call to "test_throughput"
+                        break
+
+    assigned_nodes_resp = await client.get_assigned_nodes()
+    if len(assigned_nodes_resp.nodes) == 0:
+        click.echo("No nodes are assigned to the transceiver. Assign nodes and try again.")
+        return
+
+    try:
+        async with asyncio.TaskGroup() as tg:
+            for node in assigned_nodes_resp.nodes:
+                tg.create_task(test_throughput(node.address))
+    except ExceptionGroup as ex_group:
+        for ex in ex_group.exceptions:
+            click.echo(ex)
+
+
+@transceiver_group.command()
+@with_transceiver_client
+async def snippet_throughput(client: TransceiverClient):
+    """Measure concurrent throughput of snippet data."""
+
+    async def test_throughput(addr):
+        async with ProxyAVSSClient(client, addr) as node:
+            with node.reports(parse=False) as reports:
+                click.echo(f"{addr}: Requesting snippet reports...")
                 await node.test_throughput(duration=duration*1000)
                 test = await anext(reports)
 


### PR DESCRIPTION
Add a switch to base throughput measurements on Snippet Reports since it has been found that the test data generated by the Throughput Test command may not always be representative of real world performance.