### PR TITLE
USB transceiver support

### DIFF
--- a/anura/cli/avss_commands.py
+++ b/anura/cli/avss_commands.py
@@ -15,7 +15,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 def with_avss_client(f):
-    @click.option("--transceiver", help="Hostname or IP address")
+    @click.option("--transceiver", help="Hostname, IP address or usb:<serial>")
     @click.option("--transceiver-port", default=7645, show_default=True, help="TCP port number")
     @click.option("--address", help="Bluetooth address of AVSS node.", required=True)
     @functools.wraps(f)
@@ -75,7 +75,7 @@ def scan():
     asyncio.run(do_async())
 
 @avss_group.command()
-@click.option("--transceiver", help="Hostname or IP address")
+@click.option("--transceiver", help="Hostname, IP address or usb:<serial>")
 @click.option("--transceiver-port", default=7645, show_default=True, help="TCP port number")
 @click.option("--address", help="Bluetooth address of AVSS node.", required=True)
 @click.option("--file", metavar="FILE", help="Path to firmware image.")

--- a/anura/transceiver/transport/__init__.py
+++ b/anura/transceiver/transport/__init__.py
@@ -1,2 +1,3 @@
 from .tcp import TCPTransport
+from .usb import USBTransport
 from .base import Transport

--- a/anura/transceiver/transport/__init__.py
+++ b/anura/transceiver/transport/__init__.py
@@ -1,0 +1,2 @@
+from .tcp import TCPTransport
+from .base import Transport

--- a/anura/transceiver/transport/base.py
+++ b/anura/transceiver/transport/base.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+
+
+class Transport(ABC):
+    _registry = {}
+
+    def __init_subclass__(cls, transport_type: str, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._registry[transport_type] = cls
+
+    @abstractmethod
+    async def open_connection(self) -> None:
+        pass
+
+    @abstractmethod
+    async def send(self, payload: bytes) -> None:
+        pass
+
+    @abstractmethod
+    async def read(self) -> bytes:
+        pass
+
+    @abstractmethod
+    async def close(self) -> None:
+        pass
+
+    @classmethod
+    def create(cls, target_spec: str, *args, **kwargs):
+        """Instantiate a Transport class
+
+        Args:
+            target_spec (str): A string that specifies the target device
+                using the format <transport>:<target>. If <transport>: is
+                omitted it defaults to `'tcp:'`.
+
+            *args: In the case of TCP this is optionally the port
+                number as a string. The arguments are passed to the
+                subclass.
+            *kwargs: Passed to the subclass.
+
+        """
+        if ":" in target_spec:
+            transport_type, target = target_spec.split(":", 1)
+        else:
+            transport_type, target = "tcp", target_spec
+
+        return cls._registry[transport_type](target, *args, **kwargs)

--- a/anura/transceiver/transport/tcp.py
+++ b/anura/transceiver/transport/tcp.py
@@ -1,0 +1,37 @@
+import asyncio
+from typing import Tuple
+import struct
+from .base import Transport
+
+
+class TCPTransport(Transport, transport_type="tcp"):
+    """
+    TCP/IP based transceiver transport.
+    """
+
+    def __init__(self, hostname: str, port: str) -> None:
+        self._hostname = hostname
+        self._port = port
+
+    async def open_connection(self):
+        self._reader, self._writer = await asyncio.open_connection(
+            self._hostname, self._port
+        )
+
+    async def send(self, payload):
+        self._writer.write(struct.pack(">H", len(payload)))
+        self._writer.write(payload)
+        await self._writer.drain()
+
+    async def read(self):
+        header = await self._reader.readexactly(2)
+        (payload_len,) = struct.unpack(">H", header)
+        payload = await self._reader.readexactly(payload_len)
+        return payload
+
+    async def close(self):
+        if self._writer is None:
+            return
+        self._writer.close()
+        await self._writer.wait_closed()
+        self._writer = None

--- a/anura/transceiver/transport/usb.py
+++ b/anura/transceiver/transport/usb.py
@@ -1,0 +1,172 @@
+from .base import Transport
+
+import argparse
+import asyncio
+import errno
+import logging
+import struct
+import sys
+from typing import Tuple, Optional, List
+
+import usb.core
+import usb.util
+
+logger = logging.getLogger(__name__)
+
+# XXX: placeholders until we get proper ids
+VENDOR_ID = 0xF0F0
+PRODUCT_ID = 0x5256
+
+OUT_ENDPOINT = 0x01  # host to device
+IN_ENDPOINT = 0x81  # device to host
+MAX_PACKET_SIZE = 64
+
+EOF_SENTINEL = object()  # end of the receive queue
+
+
+class USBTransport(Transport, transport_type="usb"):
+    """
+    Connects to a USB transceiver identified by its serial number.
+    """
+
+    def __init__(self, serial_number: str, _unused_port) -> None:
+        self.serial_number = serial_number
+        self.vendor_id = VENDOR_ID
+        self.product_id = PRODUCT_ID
+        self.in_ep = IN_ENDPOINT
+        self.out_ep = OUT_ENDPOINT
+        self.max_packet_size = MAX_PACKET_SIZE
+        self.dev: Optional[usb.core.Device] = None
+        self.receive_queue: asyncio.Queue = asyncio.Queue()
+        self.loop = asyncio.get_event_loop()
+        self.reader_task: Optional[asyncio.Task] = None
+
+    async def open_connection(self) -> None:
+        device = await self.loop.run_in_executor(
+            None, self._find_device_by_serial, self.serial_number
+        )
+        if device is None:
+            raise ValueError(
+                f"USB device with serial number '{self.serial_number}' not found"
+            )
+
+        logger.debug(f"Transceiver found: {device}")
+        self.dev = device
+
+        # Get rid of the kernel driver (if there is one) and claim the
+        # default interface
+        await self.loop.run_in_executor(None, self._detach_kernel_driver)
+        usb.util.claim_interface(self.dev, 0)
+
+        # Start the background reader task that puts messages on the
+        # receive queue
+        self.reader_task = asyncio.create_task(self._background_reader())
+
+    async def send(self, msg: bytes) -> None:
+        assert self.dev is not None
+
+        if len(msg) > 0xFFFF:
+            raise ValueError("Message too large", len(msg))
+        packet = struct.pack(">H", len(msg)) + msg
+
+        # Send the message to the device, with a timeout
+        await self.loop.run_in_executor(None, self.dev.write, self.out_ep, packet, 1000)
+        logger.debug(f"Sent message: {msg}")
+
+    async def read(self) -> bytes:
+        assert self.dev is not None
+
+        message = await self.receive_queue.get()
+        if message is EOF_SENTINEL:
+            logger.error("USB connection closed during read")
+            raise asyncio.IncompleteReadError(partial=b"", expected=1)
+
+        logger.debug(f"Dequeued message: {message}")
+
+        return message
+
+    async def close(self) -> None:
+        if self.dev is None:
+            return
+
+        dev = self.dev
+        self.dev = None
+
+        if self.reader_task:
+            self.reader_task.cancel()
+            try:
+                await self.reader_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.error(f"Error while cancelling reader task: {e}")
+
+        usb.util.release_interface(dev, 0)
+        usb.util.dispose_resources(dev)
+        logger.debug("USB interface released")
+
+        await self.receive_queue.put(EOF_SENTINEL)
+
+    @staticmethod
+    def list_devices() -> List[str]:
+        """Get a list of serial numbers of connected transceivers."""
+        devices = usb.core.find(find_all=True, idVendor=VENDOR_ID, idProduct=PRODUCT_ID)
+        device_list = []
+        for device in devices:
+            serial = usb.util.get_string(device, device.iSerialNumber)
+            if serial:
+                device_list.append(serial)
+
+        return device_list
+
+    def _detach_kernel_driver(self):
+        if self.dev.is_kernel_driver_active(0):
+            self.dev.detach_kernel_driver(0)
+            logger.debug("Kernel driver detached")
+
+    def _find_device_by_serial(self, serial_number: str) -> Optional[usb.core.Device]:
+        devices = usb.core.find(
+            find_all=True, idVendor=self.vendor_id, idProduct=self.product_id
+        )
+        for device in devices:
+            dev_serial = usb.util.get_string(device, device.iSerialNumber)
+            if dev_serial == serial_number:
+                return device
+
+    async def _background_reader(self) -> None:
+        # Task to always have a read pending on the IN endpoint
+        buf = bytearray()
+        while self.dev is not None:
+            try:
+                data = await self.loop.run_in_executor(
+                    None, self.dev.read, self.in_ep, self.max_packet_size
+                )
+                buf.extend(data)
+                logger.debug(f"Received raw data: {data}")
+
+                while True:
+                    if len(buf) < 2:
+                        break  # need more data
+
+                    msg_length = struct.unpack(">H", buf[:2])[0]
+                    total_length = 2 + msg_length
+
+                    if len(buf) < total_length:
+                        break  # need more data
+
+                    # Pass on the CBOR payload
+                    msg = bytes(buf[2:total_length])
+                    buf = buf[total_length:]
+                    logger.debug(f"Received payload: {msg}")
+                    await self.receive_queue.put(msg)
+
+            except usb.core.USBError as e:
+                logger.error(f"USB Error while receiving: {e}")
+                await self.close()
+                break
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Unexpected error in background reader: {e}")
+                await self.close()
+                break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ name = "pyanura"
 requires-python = ">=3.11"
 dependencies = [
   "cbor2",
-  "typing_inspect"
+  "typing_inspect",
+  "pyusb",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mypy-extensions==1.0.0
 typing-inspect==0.9.0
 typing_extensions==4.11.0
 zeroconf==0.132.2
+pyusb==1.2.1


### PR DESCRIPTION
This adds USB transceiver support. The Client class now uses the new Transport class that supports both TCP and USB. You can connect to a USB device by giving the client a hostname like `usb:<serial>`.

Closes: #30 