### PR TITLE
transceiver: transport: Gracefully handle missing pyusb module

### DIFF
--- a/anura/transceiver/transport/__init__.py
+++ b/anura/transceiver/transport/__init__.py
@@ -1,3 +1,6 @@
 from .tcp import TCPTransport
-from .usb import USBTransport
+try:
+    from .usb import USBTransport
+except ModuleNotFoundError:
+    from .usb_dummy import USBTransport
 from .base import Transport

--- a/anura/transceiver/transport/usb_dummy.py
+++ b/anura/transceiver/transport/usb_dummy.py
@@ -1,0 +1,30 @@
+import logging
+
+from .base import Transport
+
+logger = logging.getLogger(__name__)
+
+class USBTransport(Transport, transport_type="usb"):
+    """
+    Dummy replacement for the USBTransport class in case the pyusb
+    module is missing.
+    """
+
+    def __init__(self, serial_number: str, _unused_port) -> None:
+        raise RuntimeError("Can't instantiate USBTransport due a missing module.")
+
+    @staticmethod
+    def list_devices() -> list[str]:
+        return []
+
+    async def open_connection(self):
+        pass
+
+    async def send(self, payload):
+        pass
+
+    async def read(self):
+        pass
+
+    async def close(self):
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,17 @@ requires-python = ">=3.11"
 dependencies = [
   "cbor2",
   "typing_inspect",
-  "pyusb",
 ]
 
 [project.optional-dependencies]
+usb = [
+  "pyusb",
+]
 cli = [
   "click",
   "bleak",
-  "zeroconf"
+  "pyusb",
+  "zeroconf",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Make pyusb into an optional depdendency by gracefully handling the case wheere pyusb is missing by replacing USBTransport with a non-functional dummy in case of a ModuleNotFoundError when it is imported.

This lets you import and use all non-usb related features of pyanura without requiring the pyusb dependency.

Attempting to use "usb:<SERIAL>" to create a TransceiverClient when pyusb is missing results in a runtime error.