### PR TITLE
99-anura.rules: Lowercase VID & PID

### DIFF
--- a/99-anura.rules
+++ b/99-anura.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="16D0", ATTR{idProduct}=="13D4", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="13d4", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
VID and PID must be lowercase for the rule to match. Logically it shouldn't matter but the attribute
is compared as a string and not as a number.