### PR TITLE
avss: client: Add support for reset report commmand

### DIFF
--- a/anura/avss/client.py
+++ b/anura/avss/client.py
@@ -79,6 +79,7 @@ OpCode.ReportCapture = 13 # TBD
 OpCode.Deactivate = 16
 OpCode.GetFirmwareInfo = 18
 OpCode.GetFirmwareInfoResponse = 19
+OpCode.ResetReport = 20
 OpCode.PrepareUpgrade = 100
 OpCode.ApplyUpgrade = 101
 OpCode.ConfirmUpgrade = 102
@@ -379,6 +380,9 @@ class AVSSClient:
 
     async def get_firmware_info(self) -> GetFirmwareInfoResponse:
         return await self._request(OpCode.GetFirmwareInfo, None)
+
+    async def reset_report(self):
+        return await self._request(OpCode.ResetReport, None)
 
     def _on_program_notify(self, data):
         offset, = struct.unpack("<L", data)


### PR DESCRIPTION
The reset report command cancels all ongoing report subscriptions.