### PR TITLE
avss: client: TriggerMeasurementArgs import added

### DIFF
--- a/anura/avss/client.py
+++ b/anura/avss/client.py
@@ -36,6 +36,7 @@ from .models import (
     SettingsReport,
     SnippetReport,
     TestThroughputArgs,
+    TriggerMeasurementArgs,
     WriteSettingsResponse,
     WriteSettingsV2Args,
     WriteSettingsV2Response,


### PR DESCRIPTION
trigger_measurement() did not work when using pyanura as a dependency in Vibreshark