### PR TITLE
Add upload progress callbacks to DFU transfer loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `SnippetReport` and `CaptureReport` now decode the timing fields added in firmware v26.4.0 (`duration`, `start_time_monotonic`, `duration_monotonic`, `transmission_offset`); all are optional, so reports from older firmware still decode.
+- Optional `progress` callback on `TransceiverClient.dfu_write_image` and `AVSSClient.program_transfer`, invoked with the cumulative byte count after each chunk so embedders can drive upload-progress UI without re-implementing the transfer loop.
+- `pyanura-cli` now shows a progress bar while uploading firmware images (`transceiver upgrade` and `avss upgrade`), driven by the new `progress` callbacks.
 - CI: a pyright type-check job that runs both with and without the optional `ble`/`usb` extras, keeping the library type-clean in either configuration.
 
 ### Changed
+- The firmware-transfer loops (`dfu_write_image`, `program_transfer`) no longer emit per-chunk `INFO` log records. Callers wanting progress should pass the new `progress` callback instead.
 - Reworked CBOR (un)marshalling to carry wire keys via `typing.Annotated` (`CborKey`) plus a per-type codec registry, replacing the `cbor_field` helper. Protocol model dataclasses now keep their real field types, so constructing and consuming them is fully type-checked. The on-the-wire CBOR format is unchanged.
 
 ### Removed

--- a/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
@@ -17,6 +17,7 @@ from anura.transceiver.client import TransceiverClient
 from anura.transceiver.models import BluetoothAddrLE
 from anura.transceiver.proxy_avss_client import ProxyAVSSClient
 
+from .progress import upload_progress
 from .session import SessionFile
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,10 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
             if not confirm_only:
                 async with BleakAVSSClient(device) as client:
                     await client.prepare_upgrade(image_index, len(binary))
-                    await client.program_transfer(binary)
+                    with upload_progress(
+                        len(binary), "Uploading firmware"
+                    ) as on_progress:
+                        await client.program_transfer(binary, progress=on_progress)
                     await client.apply_upgrade()
 
                 click.echo("Waiting for node to reboot with new firmware image...")
@@ -156,7 +160,12 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
                 if not confirm_only:
                     async with ProxyAVSSClient(trx_client, address) as client:
                         await client.prepare_upgrade(image_index, len(binary))
-                        await client.program_transfer(binary)
+                        with upload_progress(
+                            len(binary), "Uploading firmware"
+                        ) as on_progress:
+                            await client.program_transfer(
+                                binary, progress=on_progress
+                            )
                         await client.apply_upgrade()
 
                     click.echo("Waiting for node to reboot with new firmware image...")

--- a/packages/pyanura-cli/src/pyanura_cli/progress.py
+++ b/packages/pyanura-cli/src/pyanura_cli/progress.py
@@ -1,0 +1,27 @@
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+import click
+
+
+@contextmanager
+def upload_progress(length: int, label: str) -> Iterator[Callable[[int], None]]:
+    """Yield a progress callback that drives a click progress bar.
+
+    The callback expects the cumulative number of bytes transferred so far,
+    matching the ``progress`` callbacks on ``dfu_write_image`` and
+    ``program_transfer``.
+
+    Usage:
+        with upload_progress(len(image), "Uploading") as on_progress:
+            await client.program_transfer(image, progress=on_progress)
+    """
+    with click.progressbar(length=length, label=label) as bar:
+        sent = 0
+
+        def on_progress(total_sent: int) -> None:
+            nonlocal sent
+            bar.update(total_sent - sent)
+            sent = total_sent
+
+        yield on_progress

--- a/packages/pyanura-cli/src/pyanura_cli/transceiver_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/transceiver_commands.py
@@ -13,6 +13,8 @@ from anura.transceiver.models import BluetoothAddrLE, ScanNodesReceivedEvent
 from anura.transceiver.proxy_avss_client import ProxyAVSSClient
 from anura.transceiver.transport import USBTransport
 
+from .progress import upload_progress
+
 logger = logging.getLogger(__name__)
 
 
@@ -270,7 +272,10 @@ def upgrade(host, port, file, confirm_only):
             if not confirm_only:
                 async with TransceiverClient(host, port) as trx:
                     await trx.dfu_prepare(size=len(image))
-                    await trx.dfu_write_image(image)
+                    with upload_progress(
+                        len(image), "Uploading firmware"
+                    ) as on_progress:
+                        await trx.dfu_write_image(image, progress=on_progress)
                     await trx.dfu_apply()
 
                 click.echo(

--- a/src/anura/avss/client.py
+++ b/src/anura/avss/client.py
@@ -523,7 +523,20 @@ class AVSSClient:
         if self._program_nack_queue:
             self._program_nack_queue.put_nowait(offset)
 
-    async def program_transfer(self, binary, att_mtu=243):
+    async def program_transfer(
+        self,
+        binary,
+        att_mtu=243,
+        progress: Callable[[int], None] | None = None,
+    ):
+        """Transfer a firmware binary to a node, optionally reporting progress.
+
+        Args:
+            binary:   Raw firmware binary (after ``prepare_upgrade`` was called).
+            att_mtu:  ATT MTU for the connection.
+            progress: Optional callback invoked with the cumulative number of
+                      bytes written so far, after each chunk.
+        """
         # Write without response is limited to ATT MTU - 3 and
         # we use 4 bytes for offset.
         chunk_size = (att_mtu - 3) - 4
@@ -558,7 +571,8 @@ class AVSSClient:
                 else:
                     req.extend(binary[offset:])
                 offset = end
-                logger.info(
-                    f"Program {offset}/{len(binary)} ({offset * 100 / len(binary):.0f} %)"
-                )
                 await self._transport.program_write(bytes(req))
+                if progress is not None:
+                    # offset can overshoot on the final chunk since it is not
+                    # clamped above; report the true byte count.
+                    progress(min(offset, len(binary)))

--- a/src/anura/transceiver/client.py
+++ b/src/anura/transceiver/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from collections.abc import AsyncIterator, Callable, Generator
 from contextlib import contextmanager
 from typing import (
@@ -20,8 +19,6 @@ from .exceptions import (
     TransceiverRequestError,
 )
 from .transport import Transport
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -277,18 +274,28 @@ class TransceiverClient:
         args = models.DfuWriteArgs(offset=offset, data=data)
         return await self.request("dfu_write", args)
 
-    async def dfu_write_image(self, image: bytes, chunk_size=300):
+    async def dfu_write_image(
+        self,
+        image: bytes,
+        chunk_size: int = 300,
+        progress: Callable[[int], None] | None = None,
+    ):
+        """Write a firmware image in chunks, optionally reporting progress.
+
+        Args:
+            image:      Raw firmware binary (after ``dfu_prepare`` was called).
+            chunk_size: Number of bytes per ``dfu_write`` request.
+            progress:   Optional callback invoked with the cumulative number of
+                        bytes written so far, after each chunk.
+        """
         offset = 0
-        while offset < len(image):
-            if offset + chunk_size < len(image):
-                chunk = image[offset : (offset + chunk_size)]
-            else:
-                chunk = image[offset:]
-            logger.info(
-                f"Writing image offset={offset} ({int(offset / len(image) * 100)}%)"
-            )
-            await self.dfu_write(offset, chunk)
-            offset += len(chunk)
+        total = len(image)
+        while offset < total:
+            end = min(offset + chunk_size, total)
+            await self.dfu_write(offset, image[offset:end])
+            offset = end
+            if progress is not None:
+                progress(offset)
 
     async def dfu_apply(self, permanent=False):
         if permanent:


### PR DESCRIPTION
dfu_write_image and program_transfer gain an optional progress callback, invoked with the cumulative byte count after each chunk.

Drop the per-chunk INFO logging from both loop; a library should stay quiet by default.

Wire the callbacks into pyanura-cli's firmware-upgrade commands via a shared upload_progress helper that drives a click progress bar.