### PR TITLE
Windowed DFU transfer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which prepares and uploads an image using the windowed transfer and falls
   back to the legacy transfer on node firmware without support; `pyanura-cli`
   now uses it for `avss upgrade`.
-- `SnippetReport` and `CaptureReport` now decode the timing fields added in firmware v26.4.0 (`duration`, `start_time_monotonic`, `duration_monotonic`, `transmission_offset`); all are optional, so reports from older firmware still decode.
-- Optional `progress` callback on `TransceiverClient.dfu_write_image` and `AVSSClient.program_transfer`, invoked with the cumulative byte count after each chunk so embedders can drive upload-progress UI without re-implementing the transfer loop.
-- `pyanura-cli` now shows a progress bar while uploading firmware images (`transceiver upgrade` and `avss upgrade`), driven by the new `progress` callbacks.
-- CI: a pyright type-check job that runs both with and without the optional `ble`/`usb` extras, keeping the library type-clean in either configuration.
 
 ### Changed
 - The firmware-transfer loops (`dfu_write_image`, `program_transfer`) no longer emit per-chunk `INFO` log records. Callers wanting progress should pass the new `progress` callback instead.
-- Reworked CBOR (un)marshalling to carry wire keys via `typing.Annotated` (`CborKey`) plus a per-type codec registry, replacing the `cbor_field` helper. Protocol model dataclasses now keep their real field types, so constructing and consuming them is fully type-checked. The on-the-wire CBOR format is unchanged.
-
-### Removed
-- The internal `cbor_field` helper, superseded by `Annotated[..., CborKey(n)]` and `register_codec`.
 
 ### Fixed
 - `AVSSControlPointError.from_response` raised `TypeError` instead of the
@@ -40,6 +32,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The transfer now confirms completion by requiring NACK silence after the
   final chunk and re-sending it as a probe, recovering both late NACKs and a
   silently dropped final chunk.
+
+## [1.0.0] - 2026-07-04
+
+### Added
+- `SnippetReport` and `CaptureReport` now decode the timing fields added in firmware v26.4.0 (`duration`, `start_time_monotonic`, `duration_monotonic`, `transmission_offset`); all are optional, so reports from older firmware still decode.
+- Optional `progress` callback on `TransceiverClient.dfu_write_image` and `AVSSClient.program_transfer`, invoked with the cumulative byte count after each chunk so embedders can drive upload-progress UI without re-implementing the transfer loop.
+- `pyanura-cli` now shows a progress bar while uploading firmware images (`transceiver upgrade` and `avss upgrade`), driven by the new `progress` callbacks.
+- CI: a pyright type-check job that runs both with and without the optional `ble`/`usb` extras, keeping the library type-clean in either configuration.
+
+### Changed
+- Reworked CBOR (un)marshalling to carry wire keys via `typing.Annotated` (`CborKey`) plus a per-type codec registry, replacing the `cbor_field` helper. Protocol model dataclasses now keep their real field types, so constructing and consuming them is fully type-checked. The on-the-wire CBOR format is unchanged.
+
+### Removed
+- The internal `cbor_field` helper, superseded by `Annotated[..., CborKey(n)]` and `register_codec`.
+
+### Fixed
 - `DfuWriteArgs.data` is now correctly typed as `bytes` (it was previously annotated `int`).
 - pyanura now type-checks cleanly under pyright; corrected latent `Optional`-narrowing and return-type annotations in the USB and TCP transports.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The internal `cbor_field` helper, superseded by `Annotated[..., CborKey(n)]` and `register_codec`.
 
 ### Fixed
+- `AVSSControlPointError.from_response` raised `TypeError` instead of the
+  proper AVSS exception for any device error response on Python 3.11, where
+  `int in IntEnum` membership tests are not supported.
 - The legacy AVSS firmware transfer no longer reports completion while the
   node is still missing data, which made the subsequent Apply Upgrade fail.
   The transfer now confirms completion by requiring NACK silence after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The internal `cbor_field` helper, superseded by `Annotated[..., CborKey(n)]` and `register_codec`.
 
 ### Fixed
+- The legacy AVSS firmware transfer no longer reports completion while the
+  node is still missing data, which made the subsequent Apply Upgrade fail.
+  The transfer now confirms completion by requiring NACK silence after the
+  final chunk and re-sending it as a probe, recovering both late NACKs and a
+  silently dropped final chunk.
 - `DfuWriteArgs.data` is now correctly typed as `bytes` (it was previously annotated `int`).
 - pyanura now type-checks cleanly under pyright; corrected latent `Optional`-narrowing and return-type annotations in the USB and TCP transports.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for the AVSS windowed DFU transfer (Prepare Upgrade V2), adding
+  flow control and resumption of interrupted transfers.
+  `AVSSClient.program_transfer` uses it when the node supports it and falls
+  back to the legacy transfer otherwise.
+- `AVSSClient.prepare_upgrade_v2`, the
+  `PrepareUpgradeV2Args`/`PrepareUpgradeV2Response` models, and
+  `AVSSProgramTransferError`.
+
+### Breaking
+- `AVSSClient.program_transfer` now prepares the upgrade itself and its
+  parameters are keyword-only, with a new required `image` parameter. Drop
+  any preceding `prepare_upgrade` call.
 - `SnippetReport` and `CaptureReport` now decode the timing fields added in firmware v26.4.0 (`duration`, `start_time_monotonic`, `duration_monotonic`, `transmission_offset`); all are optional, so reports from older firmware still decode.
 - Optional `progress` callback on `TransceiverClient.dfu_write_image` and `AVSSClient.program_transfer`, invoked with the cumulative byte count after each chunk so embedders can drive upload-progress UI without re-implementing the transfer loop.
 - `pyanura-cli` now shows a progress bar while uploading firmware images (`transceiver upgrade` and `avss upgrade`), driven by the new `progress` callbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for the AVSS windowed DFU transfer (Prepare Upgrade V2), adding
-  flow control and resumption of interrupted transfers.
-  `AVSSClient.program_transfer` uses it when the node supports it and falls
-  back to the legacy transfer otherwise.
-- `AVSSClient.prepare_upgrade_v2`, the
-  `PrepareUpgradeV2Args`/`PrepareUpgradeV2Response` models, and
-  `AVSSProgramTransferError`.
-
-### Breaking
-- `AVSSClient.program_transfer` now prepares the upgrade itself and its
-  parameters are keyword-only, with a new required `image` parameter. Drop
-  any preceding `prepare_upgrade` call.
+  flow control and resumption of interrupted transfers:
+  `AVSSClient.prepare_upgrade_v2` and `AVSSClient.program_transfer_windowed`,
+  plus the `PrepareUpgradeV2Args`/`PrepareUpgradeV2Response` models and
+  `AVSSProgramTransferError`. The existing `prepare_upgrade`/`program_transfer`
+  pair is unchanged.
+- `anura.avss.procedures`: high-level procedures composing the low-level
+  client methods into complete transactions. The first is `upload_firmware`,
+  which prepares and uploads an image using the windowed transfer and falls
+  back to the legacy transfer on node firmware without support; `pyanura-cli`
+  now uses it for `avss upgrade`.
 - `SnippetReport` and `CaptureReport` now decode the timing fields added in firmware v26.4.0 (`duration`, `start_time_monotonic`, `duration_monotonic`, `transmission_offset`); all are optional, so reports from older firmware still decode.
 - Optional `progress` callback on `TransceiverClient.dfu_write_image` and `AVSSClient.program_transfer`, invoked with the cumulative byte count after each chunk so embedders can drive upload-progress UI without re-implementing the transfer loop.
 - `pyanura-cli` now shows a progress bar while uploading firmware images (`transceiver upgrade` and `avss upgrade`), driven by the new `progress` callbacks.

--- a/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
@@ -12,6 +12,7 @@ from bleak import BleakScanner
 from bleak.exc import BleakError
 
 import anura.avss as avss
+from anura.avss import procedures
 from anura.avss.bleak_avss_client import BleakAVSSClient
 from anura.transceiver.client import TransceiverClient
 from anura.transceiver.models import BluetoothAddrLE
@@ -126,8 +127,8 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
                     with upload_progress(
                         len(binary), "Uploading firmware"
                     ) as on_progress:
-                        await client.program_transfer(
-                            binary, image=image_index, progress=on_progress
+                        await procedures.upload_firmware(
+                            client, binary, image=image_index, progress=on_progress
                         )
                     await client.apply_upgrade()
 
@@ -163,8 +164,8 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
                         with upload_progress(
                             len(binary), "Uploading firmware"
                         ) as on_progress:
-                            await client.program_transfer(
-                                binary, image=image_index, progress=on_progress
+                            await procedures.upload_firmware(
+                                client, binary, image=image_index, progress=on_progress
                             )
                         await client.apply_upgrade()
 

--- a/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
@@ -123,11 +123,12 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
 
             if not confirm_only:
                 async with BleakAVSSClient(device) as client:
-                    await client.prepare_upgrade(image_index, len(binary))
                     with upload_progress(
                         len(binary), "Uploading firmware"
                     ) as on_progress:
-                        await client.program_transfer(binary, progress=on_progress)
+                        await client.program_transfer(
+                            binary, image=image_index, progress=on_progress
+                        )
                     await client.apply_upgrade()
 
                 click.echo("Waiting for node to reboot with new firmware image...")
@@ -159,12 +160,11 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
 
                 if not confirm_only:
                     async with ProxyAVSSClient(trx_client, address) as client:
-                        await client.prepare_upgrade(image_index, len(binary))
                         with upload_progress(
                             len(binary), "Uploading firmware"
                         ) as on_progress:
                             await client.program_transfer(
-                                binary, progress=on_progress
+                                binary, image=image_index, progress=on_progress
                             )
                         await client.apply_upgrade()
 

--- a/src/anura/avss/__init__.py
+++ b/src/anura/avss/__init__.py
@@ -1,5 +1,6 @@
 from . import exceptions as exceptions
 from . import models as models
+from . import procedures as procedures
 from . import transport as transport
 from . import uuids as uuids
 from .client import AVSSClient, Report

--- a/src/anura/avss/__init__.py
+++ b/src/anura/avss/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
     AVSSControlPointError,
     AVSSError,
     AVSSOpCodeUnsupportedError,
+    AVSSProgramTransferError,
     AVSSProtocolError,
     AVSSTransportError,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "AVSSControlPointError",
     "AVSSError",
     "AVSSOpCodeUnsupportedError",
+    "AVSSProgramTransferError",
     "AVSSProtocolError",
     "AVSSTransportError",
     "AggregatedValuesReport",

--- a/src/anura/avss/client.py
+++ b/src/anura/avss/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import hashlib
 import logging
 import struct
 import time
@@ -23,7 +22,6 @@ from anura.marshalling import marshal, unmarshal
 from .exceptions import (
     AVSSConnectionError,
     AVSSControlPointError,
-    AVSSOpCodeUnsupportedError,
     AVSSProgramTransferError,
     AVSSProtocolError,
     AVSSTransportError,
@@ -582,37 +580,26 @@ class AVSSClient:
     async def program_transfer(
         self,
         binary,
-        *,
-        image: int,
         att_mtu=243,
         progress: Callable[[int], None] | None = None,
-        prepare_timeout=30.0,
     ):
-        """Prepare and transfer a firmware binary to a node.
+        """Transfer a firmware binary using the unsynchronized procedure.
 
-        Prepares the upgrade and runs a windowed transfer with flow control
-        in one flow (Prepare Upgrade V2), falling back to the legacy
-        Prepare Upgrade command and the unsynchronized transfer on node
-        firmware without windowed transfer support. A separate
-        ``prepare_upgrade`` call is not needed.
+        The upgrade must have been prepared with ``prepare_upgrade``. On
+        nodes that support it, prefer the windowed procedure
+        (``prepare_upgrade_v2`` + ``program_transfer_windowed``) or the
+        complete flow in :func:`anura.avss.procedures.upload_firmware`.
 
-        An interrupted windowed transfer of the same binary is resumed from
-        the first byte the node has not received, rather than restarted.
+        Completion is confirmed before returning: after the final chunk the
+        transfer waits out late NACKs and probes the node by re-sending the
+        final chunk, so a node still missing data is caught and served
+        rather than left waiting.
 
         Args:
-            binary:   Raw firmware binary.
-            image:    Index of the firmware image to be uploaded.
+            binary:   Raw firmware binary (after ``prepare_upgrade`` was called).
             att_mtu:  ATT MTU for the connection.
             progress: Optional callback invoked with the cumulative number of
-                      bytes transferred so far. For a windowed transfer this
-                      is the number of bytes acknowledged by the node, which
-                      starts beyond zero when a transfer is resumed.
-            prepare_timeout: Timeout for the prepare step, which erases the
-                      upgrade slot and can take several seconds.
-
-        Raises:
-            AVSSProgramTransferError: If a windowed transfer is aborted by
-                the node or stalls without making progress.
+                      bytes written so far, after each chunk.
         """
         # Write without response is limited to ATT MTU - 3 and
         # we use 4 bytes for offset.
@@ -621,44 +608,54 @@ class AVSSClient:
         async with self._program_lock:
             self._program_notify_queue = asyncio.Queue()
             try:
-                try:
-                    resp = await self.prepare_upgrade_v2(
-                        image,
-                        len(binary),
-                        hashlib.sha256(binary).digest(),
-                        timeout=prepare_timeout,
-                    )
-                except AVSSOpCodeUnsupportedError:
-                    logger.info(
-                        "Windowed transfer not supported by node, "
-                        "using unsynchronized transfer"
-                    )
-                    await self.prepare_upgrade(
-                        image, len(binary), timeout=prepare_timeout
-                    )
-                    await self._program_transfer_unsynchronized(
-                        binary, chunk_size, progress
-                    )
-                    return
+                await self._unsynchronized_transfer_loop(binary, chunk_size, progress)
+            finally:
+                self._program_notify_queue = None
 
-                if resp.offset > len(binary):
-                    raise AVSSProtocolError(
-                        f"Resume offset {resp.offset} beyond image size"
-                    )
-                if resp.offset > 0:
-                    logger.info("Resuming transfer at offset %d", resp.offset)
+    async def program_transfer_windowed(
+        self,
+        binary,
+        params: PrepareUpgradeV2Response,
+        att_mtu=243,
+        progress: Callable[[int], None] | None = None,
+    ):
+        """Transfer a firmware binary using the windowed procedure.
 
-                await self._program_transfer_windowed(
-                    binary,
-                    min(chunk_size, resp.max_chunk_size),
-                    resp.window,
-                    resp.offset,
-                    progress,
+        The transfer must have been negotiated with ``prepare_upgrade_v2``,
+        whose response carries the flow-control parameters and the offset to
+        start from — beyond zero when the node resumes an interrupted
+        transfer of the same image.
+
+        Args:
+            binary:   Raw firmware binary.
+            params:   The ``prepare_upgrade_v2`` response.
+            att_mtu:  ATT MTU for the connection.
+            progress: Optional callback invoked with the cumulative number
+                      of bytes acknowledged by the node.
+
+        Raises:
+            AVSSProgramTransferError: If the transfer is aborted by the node
+                or stalls without making progress.
+        """
+        # Write without response is limited to ATT MTU - 3 and
+        # we use 4 bytes for offset.
+        chunk_size = min((att_mtu - 3) - 4, params.max_chunk_size)
+
+        if params.offset > len(binary):
+            raise AVSSProtocolError(f"Resume offset {params.offset} beyond image size")
+        if params.offset > 0:
+            logger.info("Resuming transfer at offset %d", params.offset)
+
+        async with self._program_lock:
+            self._program_notify_queue = asyncio.Queue()
+            try:
+                await self._windowed_transfer_loop(
+                    binary, chunk_size, params.window, params.offset, progress
                 )
             finally:
                 self._program_notify_queue = None
 
-    async def _program_transfer_windowed(
+    async def _windowed_transfer_loop(
         self,
         binary: bytes,
         chunk_size: int,
@@ -739,7 +736,7 @@ class AVSSClient:
                 if progress is not None:
                     progress(acked)
 
-    async def _program_transfer_unsynchronized(
+    async def _unsynchronized_transfer_loop(
         self,
         binary: bytes,
         chunk_size: int,

--- a/src/anura/avss/client.py
+++ b/src/anura/avss/client.py
@@ -1,7 +1,9 @@
 import asyncio
+import hashlib
 import logging
 import struct
 import time
+from collections import deque
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -21,6 +23,8 @@ from anura.marshalling import marshal, unmarshal
 from .exceptions import (
     AVSSConnectionError,
     AVSSControlPointError,
+    AVSSOpCodeUnsupportedError,
+    AVSSProgramTransferError,
     AVSSProtocolError,
     AVSSTransportError,
 )
@@ -36,6 +40,8 @@ from .models import (
     GetVersionResponse,
     HealthReport,
     PrepareUpgradeArgs,
+    PrepareUpgradeV2Args,
+    PrepareUpgradeV2Response,
     ReportAggregatesArgs,
     ReportCaptureArgs,
     ReportHealthArgs,
@@ -70,6 +76,13 @@ _ParsedReport: TypeAlias = (
 SEGMENT_FIRST = 0x80
 SEGMENT_LAST = 0x40
 SEGMENT_NUMBER_MASK = 0x3F
+
+PROGRAM_OFFSET_ABORT = 0xFFFFFFFF
+# A windowed transfer with an exhausted window and no notification for this
+# long rewinds to the acked offset and retransmits, in case an ack was lost.
+PROGRAM_STALL_TIMEOUT = 2.0
+# Consecutive stalls without progress before the transfer is failed.
+PROGRAM_STALL_LIMIT = 15
 
 
 @dataclass
@@ -157,7 +170,7 @@ class AVSSClient:
         self._report_buf = None
         self._on_report_callbacks = []
         self._program_lock = asyncio.Lock()
-        self._program_nack_queue = None
+        self._program_notify_queue: asyncio.Queue[bytes] | None = None
         self._control_point_lock = asyncio.Lock()
 
         self.control_point_timeout: float | None = 5.0
@@ -428,6 +441,43 @@ class AVSSClient:
         arg = PrepareUpgradeArgs(image=image, size=size)
         return await self._void_request(OpCode.PREPARE_UPGRADE, arg, timeout=timeout)
 
+    async def prepare_upgrade_v2(
+        self, image: int, size: int, digest: bytes, timeout=30.0
+    ) -> PrepareUpgradeV2Response:
+        """Prepare the node for a windowed firmware transfer.
+
+        Combines the upgrade preparation of ``prepare_upgrade`` with the
+        negotiation of the transfer flow-control parameters.
+
+        The digest identifies the transfer: when it matches a transfer
+        already in progress on the node, the transfer is resumed and
+        ``response.offset`` holds the offset to resume writing from.
+
+        Program notifications must be enabled before issuing this command.
+
+        Args:
+            image:   Index of the firmware image to be uploaded.
+            size:    Size of the firmware image in bytes.
+            digest:  SHA-256 digest of the complete firmware image (32 bytes).
+            timeout: Request timeout; preparing erases the upgrade slot,
+                     which can take several seconds.
+
+        Raises:
+            AVSSOpCodeUnsupportedError: If the node firmware only supports
+                the legacy unsynchronized transfer.
+        """
+        arg = PrepareUpgradeV2Args(image=image, size=size, digest=digest)
+        resp_opcode, resp_payload = await self._request(
+            OpCode.PREPARE_UPGRADE_V2, arg, timeout=timeout
+        )
+        if resp_opcode != OpCode.PREPARE_UPGRADE_V2_RESPONSE:
+            raise AVSSProtocolError.unexpected_response(
+                OpCode.PREPARE_UPGRADE_V2,
+                resp_opcode,
+                expected=OpCode.PREPARE_UPGRADE_V2_RESPONSE,
+            )
+        return unmarshal(PrepareUpgradeV2Response, cbor2.loads(resp_payload))
+
     async def apply_upgrade(self):
         arg = ApplyUpgradeArgs()
         return await self._void_request(OpCode.APPLY_UPGRADE, arg)
@@ -519,60 +569,208 @@ class AVSSClient:
         return await self._void_request(OpCode.TRIGGER_CAPTURE, arg)
 
     def _on_program_notify(self, data):
-        (offset,) = struct.unpack("<L", data)
-        if self._program_nack_queue:
-            self._program_nack_queue.put_nowait(offset)
+        if self._program_notify_queue:
+            self._program_notify_queue.put_nowait(bytes(data))
 
     async def program_transfer(
         self,
         binary,
+        *,
+        image: int,
         att_mtu=243,
         progress: Callable[[int], None] | None = None,
+        prepare_timeout=30.0,
     ):
-        """Transfer a firmware binary to a node, optionally reporting progress.
+        """Prepare and transfer a firmware binary to a node.
+
+        Prepares the upgrade and runs a windowed transfer with flow control
+        in one flow (Prepare Upgrade V2), falling back to the legacy
+        Prepare Upgrade command and the unsynchronized transfer on node
+        firmware without windowed transfer support. A separate
+        ``prepare_upgrade`` call is not needed.
+
+        An interrupted windowed transfer of the same binary is resumed from
+        the first byte the node has not received, rather than restarted.
 
         Args:
-            binary:   Raw firmware binary (after ``prepare_upgrade`` was called).
+            binary:   Raw firmware binary.
+            image:    Index of the firmware image to be uploaded.
             att_mtu:  ATT MTU for the connection.
             progress: Optional callback invoked with the cumulative number of
-                      bytes written so far, after each chunk.
+                      bytes transferred so far. For a windowed transfer this
+                      is the number of bytes acknowledged by the node, which
+                      starts beyond zero when a transfer is resumed.
+            prepare_timeout: Timeout for the prepare step, which erases the
+                      upgrade slot and can take several seconds.
+
+        Raises:
+            AVSSProgramTransferError: If a windowed transfer is aborted by
+                the node or stalls without making progress.
         """
         # Write without response is limited to ATT MTU - 3 and
         # we use 4 bytes for offset.
         chunk_size = (att_mtu - 3) - 4
-        offset = 0
 
         async with self._program_lock:
-            self._program_nack_queue = asyncio.Queue()
-
-            while offset < len(binary):
+            self._program_notify_queue = asyncio.Queue()
+            try:
                 try:
-                    while True:
-                        # Wait a short while for a NACK message to indicate the
-                        # node is not in sync with our writes.
-                        offset = await asyncio.wait_for(
-                            self._program_nack_queue.get(), timeout=0.04
-                        )
-                        if offset == 0xFFFFFFFF:
-                            raise RuntimeError("Program transfer aborted")
-                        # We received a NACK so we wait a short while to see
-                        # if any more NACKs turn up before we continue writing.
-                        # This aids re-synchronization if multiple write requests
-                        # are queued .
-                        await asyncio.sleep(0.1)
-                except TimeoutError:
-                    # No NACK was received after 40 ms of waiting so we assume
-                    # the write operation is on track.
-                    pass
-                end = offset + chunk_size
-                req = bytearray(struct.pack("<L", offset))
-                if end < len(binary):
-                    req.extend(binary[offset:end])
-                else:
-                    req.extend(binary[offset:])
-                offset = end
-                await self._transport.program_write(bytes(req))
+                    resp = await self.prepare_upgrade_v2(
+                        image,
+                        len(binary),
+                        hashlib.sha256(binary).digest(),
+                        timeout=prepare_timeout,
+                    )
+                except AVSSOpCodeUnsupportedError:
+                    logger.info(
+                        "Windowed transfer not supported by node, "
+                        "using unsynchronized transfer"
+                    )
+                    await self.prepare_upgrade(
+                        image, len(binary), timeout=prepare_timeout
+                    )
+                    await self._program_transfer_unsynchronized(
+                        binary, chunk_size, progress
+                    )
+                    return
+
+                if resp.offset > len(binary):
+                    raise AVSSProtocolError(
+                        f"Resume offset {resp.offset} beyond image size"
+                    )
+                if resp.offset > 0:
+                    logger.info("Resuming transfer at offset %d", resp.offset)
+
+                await self._program_transfer_windowed(
+                    binary,
+                    min(chunk_size, resp.max_chunk_size),
+                    resp.window,
+                    resp.offset,
+                    progress,
+                )
+            finally:
+                self._program_notify_queue = None
+
+    async def _program_transfer_windowed(
+        self,
+        binary: bytes,
+        chunk_size: int,
+        window: int,
+        start: int,
+        progress: Callable[[int], None] | None,
+    ):
+        """Windowed transfer loop.
+
+        Writes chunks while no more than ``window`` of them are outstanding,
+        retiring outstanding chunks as Transfer Status notifications advance
+        the acked offset. A notification whose acked offset does not advance
+        requests a rewind. The node discards retransmitted chunks it has
+        already received, so rewinding to the acked offset is always safe.
+        """
+        total = len(binary)
+        acked = start
+        prev_acked: int | None = None
+        send_pos = start
+        # End offsets of writes not yet covered by the acked offset,
+        # in send order.
+        outstanding: deque[int] = deque()
+        stalls = 0
+
+        if progress is not None and acked > 0:
+            progress(acked)
+
+        while acked < total:
+            # Send chunks up to the outstanding-chunk allowance.
+            while send_pos < total and len(outstanding) < window:
+                end = min(send_pos + chunk_size, total)
+                req = struct.pack("<L", send_pos) + binary[send_pos:end]
+                await self._transport.program_write(req)
+                outstanding.append(end)
+                send_pos = end
+
+            assert self._program_notify_queue is not None
+            try:
+                data = await asyncio.wait_for(
+                    self._program_notify_queue.get(), timeout=PROGRAM_STALL_TIMEOUT
+                )
+            except TimeoutError:
+                if self._transport_closed.is_set():
+                    raise AVSSConnectionError(
+                        "Disconnected during program transfer"
+                    ) from None
+                stalls += 1
+                if stalls >= PROGRAM_STALL_LIMIT:
+                    raise AVSSProgramTransferError("Program transfer stalled") from None
+                # An ack may have been lost; rewind and retransmit. The node
+                # acknowledges duplicates, resynchronizing us forward.
+                send_pos = acked
+                outstanding.clear()
+                continue
+
+            if len(data) != 5:
+                raise AVSSProtocolError(
+                    f"Malformed transfer status notification of {len(data)} bytes"
+                )
+            new_acked, window = struct.unpack("<LB", data)
+
+            if new_acked == PROGRAM_OFFSET_ABORT:
+                raise AVSSProgramTransferError("Program transfer aborted by node")
+
+            if new_acked == prev_acked:
+                # No progress since the previous notification: the node
+                # requests a rewind to the acked offset.
+                send_pos = new_acked
+                outstanding.clear()
+            prev_acked = new_acked
+
+            if new_acked > acked:
+                acked = new_acked
+                while outstanding and outstanding[0] <= acked:
+                    outstanding.popleft()
+                send_pos = max(send_pos, acked)
+                stalls = 0
                 if progress is not None:
-                    # offset can overshoot on the final chunk since it is not
-                    # clamped above; report the true byte count.
-                    progress(min(offset, len(binary)))
+                    progress(acked)
+
+    async def _program_transfer_unsynchronized(
+        self,
+        binary: bytes,
+        chunk_size: int,
+        progress: Callable[[int], None] | None,
+    ):
+        """Legacy transfer loop for nodes without windowed transfer support."""
+        offset = 0
+
+        while offset < len(binary):
+            try:
+                while True:
+                    # Wait a short while for a NACK message to indicate the
+                    # node is not in sync with our writes.
+                    assert self._program_notify_queue is not None
+                    data = await asyncio.wait_for(
+                        self._program_notify_queue.get(), timeout=0.04
+                    )
+                    (offset,) = struct.unpack("<L", data)
+                    if offset == PROGRAM_OFFSET_ABORT:
+                        raise RuntimeError("Program transfer aborted")
+                    # We received a NACK so we wait a short while to see
+                    # if any more NACKs turn up before we continue writing.
+                    # This aids re-synchronization if multiple write requests
+                    # are queued .
+                    await asyncio.sleep(0.1)
+            except TimeoutError:
+                # No NACK was received after 40 ms of waiting so we assume
+                # the write operation is on track.
+                pass
+            end = offset + chunk_size
+            req = bytearray(struct.pack("<L", offset))
+            if end < len(binary):
+                req.extend(binary[offset:end])
+            else:
+                req.extend(binary[offset:])
+            offset = end
+            await self._transport.program_write(bytes(req))
+            if progress is not None:
+                # offset can overshoot on the final chunk since it is not
+                # clamped above; report the true byte count.
+                progress(min(offset, len(binary)))

--- a/src/anura/avss/client.py
+++ b/src/anura/avss/client.py
@@ -83,6 +83,13 @@ PROGRAM_OFFSET_ABORT = 0xFFFFFFFF
 PROGRAM_STALL_TIMEOUT = 2.0
 # Consecutive stalls without progress before the transfer is failed.
 PROGRAM_STALL_LIMIT = 15
+# A legacy transfer requires this much NACK silence after the final chunk
+# before it is considered complete: a NACK can arrive well after the write
+# that triggered it.
+PROGRAM_LEGACY_SETTLE_TIMEOUT = 1.0
+# Number of times the final chunk is re-sent as a completion probe during
+# legacy transfer completion confirmation.
+PROGRAM_LEGACY_SETTLE_PROBES = 2
 
 
 @dataclass
@@ -741,36 +748,85 @@ class AVSSClient:
         """Legacy transfer loop for nodes without windowed transfer support."""
         offset = 0
 
-        while offset < len(binary):
+        while True:
+            while offset < len(binary):
+                try:
+                    while True:
+                        # Wait a short while for a NACK message to indicate the
+                        # node is not in sync with our writes.
+                        assert self._program_notify_queue is not None
+                        data = await asyncio.wait_for(
+                            self._program_notify_queue.get(), timeout=0.04
+                        )
+                        offset = self._parse_legacy_nack(data)
+                        # We received a NACK so we wait a short while to see
+                        # if any more NACKs turn up before we continue writing.
+                        # This aids re-synchronization if multiple write requests
+                        # are queued .
+                        await asyncio.sleep(0.1)
+                except TimeoutError:
+                    # No NACK was received after 40 ms of waiting so we assume
+                    # the write operation is on track.
+                    pass
+                end = offset + chunk_size
+                req = bytearray(struct.pack("<L", offset))
+                if end < len(binary):
+                    req.extend(binary[offset:end])
+                else:
+                    req.extend(binary[offset:])
+                offset = end
+                await self._transport.program_write(bytes(req))
+                if progress is not None:
+                    # offset can overshoot on the final chunk since it is not
+                    # clamped above; report the true byte count.
+                    progress(min(offset, len(binary)))
+
+            offset = await self._confirm_unsynchronized_complete(binary, chunk_size)
+            if offset >= len(binary):
+                return
+
+    @staticmethod
+    def _parse_legacy_nack(data: bytes) -> int:
+        (offset,) = struct.unpack("<L", data)
+        if offset == PROGRAM_OFFSET_ABORT:
+            raise RuntimeError("Program transfer aborted")
+        return offset
+
+    async def _confirm_unsynchronized_complete(
+        self, binary: bytes, chunk_size: int
+    ) -> int:
+        """Confirm that the node received the complete image.
+
+        The unsynchronized transfer has no positive acknowledgement, and a
+        NACK can arrive well after the chunk write that triggered it — or
+        never, if the node silently dropped the final chunk. Require a
+        period of NACK silence, then re-send the final chunk as a probe: a
+        node that has completed the transfer drops it silently, while a node
+        still waiting for data responds with a NACK holding the offset to
+        resume from.
+
+        Returns:
+            ``len(binary)`` when the transfer is confirmed complete, or the
+            offset to resume writing from.
+        """
+        total = len(binary)
+        probe_offset = max(0, total - chunk_size)
+        probes_left = PROGRAM_LEGACY_SETTLE_PROBES
+
+        while True:
+            assert self._program_notify_queue is not None
             try:
-                while True:
-                    # Wait a short while for a NACK message to indicate the
-                    # node is not in sync with our writes.
-                    assert self._program_notify_queue is not None
-                    data = await asyncio.wait_for(
-                        self._program_notify_queue.get(), timeout=0.04
-                    )
-                    (offset,) = struct.unpack("<L", data)
-                    if offset == PROGRAM_OFFSET_ABORT:
-                        raise RuntimeError("Program transfer aborted")
-                    # We received a NACK so we wait a short while to see
-                    # if any more NACKs turn up before we continue writing.
-                    # This aids re-synchronization if multiple write requests
-                    # are queued .
-                    await asyncio.sleep(0.1)
+                data = await asyncio.wait_for(
+                    self._program_notify_queue.get(),
+                    timeout=PROGRAM_LEGACY_SETTLE_TIMEOUT,
+                )
             except TimeoutError:
-                # No NACK was received after 40 ms of waiting so we assume
-                # the write operation is on track.
-                pass
-            end = offset + chunk_size
-            req = bytearray(struct.pack("<L", offset))
-            if end < len(binary):
-                req.extend(binary[offset:end])
-            else:
-                req.extend(binary[offset:])
-            offset = end
-            await self._transport.program_write(bytes(req))
-            if progress is not None:
-                # offset can overshoot on the final chunk since it is not
-                # clamped above; report the true byte count.
-                progress(min(offset, len(binary)))
+                if probes_left == 0:
+                    return total
+                probes_left -= 1
+                req = struct.pack("<L", probe_offset) + binary[probe_offset:]
+                await self._transport.program_write(req)
+                continue
+            offset = self._parse_legacy_nack(data)
+            if offset < total:
+                return offset

--- a/src/anura/avss/exceptions.py
+++ b/src/anura/avss/exceptions.py
@@ -86,11 +86,12 @@ class AVSSControlPointError(AVSSError):
         Raises:
             ValueError: If rc is ResponseCode.OK (not an error)
         """
-        # Handle raw integers (for newer/unknown codes)
+        # Handle raw integers (for newer/unknown codes). Note that
+        # `rc in ResponseCode` raises TypeError for ints before Python 3.12.
         if not isinstance(rc, ResponseCode):
-            if rc in ResponseCode:
+            try:
                 rc = ResponseCode(rc)
-            else:
+            except ValueError:
                 return AVSSControlPointError(
                     f"Device returned response code {rc} (firmware may be newer than client)",
                     response_code=rc,

--- a/src/anura/avss/exceptions.py
+++ b/src/anura/avss/exceptions.py
@@ -13,6 +13,10 @@ class AVSSTransportError(AVSSError):
     """Raised when there has been an error in the underlying transport."""
 
 
+class AVSSProgramTransferError(AVSSError):
+    """Raised when a firmware program transfer fails."""
+
+
 class AVSSProtocolError(AVSSError):
     """Raised when a protocol violation has occurred."""
 

--- a/src/anura/avss/models.py
+++ b/src/anura/avss/models.py
@@ -50,6 +50,20 @@ class ConfirmUpgradeArgs:
 
 
 @dataclass
+class PrepareUpgradeV2Args:
+    image: Annotated[int, CborKey(0)]
+    size: Annotated[int, CborKey(1)]
+    digest: Annotated[bytes, CborKey(2)]
+
+
+@dataclass
+class PrepareUpgradeV2Response:
+    max_chunk_size: Annotated[int, CborKey(0)]
+    window: Annotated[int, CborKey(1)]
+    offset: Annotated[int, CborKey(2)]
+
+
+@dataclass
 class TestThroughputArgs:
     duration: Annotated[int, CborKey(0)]
 

--- a/src/anura/avss/procedures.py
+++ b/src/anura/avss/procedures.py
@@ -1,0 +1,70 @@
+"""High-level AVSS procedures.
+
+The :class:`~anura.avss.client.AVSSClient` methods map one-to-one onto the
+protocol: one command, characteristic write sequence or transfer loop each.
+This module composes them into complete transactions — multi-step flows with
+negotiation and fallback — and is the home for future ones, e.g. a full
+settings replacement.
+"""
+
+import hashlib
+import logging
+from collections.abc import Callable
+
+from .client import AVSSClient
+from .exceptions import AVSSOpCodeUnsupportedError
+
+logger = logging.getLogger(__name__)
+
+
+async def upload_firmware(
+    client: AVSSClient,
+    binary: bytes,
+    *,
+    image: int,
+    att_mtu: int = 243,
+    progress: Callable[[int], None] | None = None,
+    prepare_timeout: float = 30.0,
+) -> None:
+    """Prepare the node and upload a firmware image.
+
+    Negotiates the windowed transfer procedure (Prepare Upgrade V2), which
+    resumes an interrupted upload of the same image from the first byte the
+    node has not received. Nodes without support are detected via the Opcode
+    Unsupported response and served with the legacy prepare and
+    unsynchronized transfer instead.
+
+    Applying and confirming the upgrade are left to the caller.
+
+    Args:
+        client:   The AVSS client to operate on.
+        binary:   Raw firmware binary.
+        image:    Index of the firmware image to be uploaded.
+        att_mtu:  ATT MTU for the connection.
+        progress: Optional callback invoked with the cumulative number of
+                  bytes transferred so far. For a windowed transfer this is
+                  the number of bytes acknowledged by the node, which starts
+                  beyond zero when a transfer is resumed.
+        prepare_timeout: Timeout for the prepare step, which erases the
+                  upgrade slot and can take several seconds.
+
+    Raises:
+        AVSSProgramTransferError: If a windowed transfer is aborted by the
+            node or stalls without making progress.
+    """
+    try:
+        params = await client.prepare_upgrade_v2(
+            image,
+            len(binary),
+            hashlib.sha256(binary).digest(),
+            timeout=prepare_timeout,
+        )
+    except AVSSOpCodeUnsupportedError:
+        logger.info(
+            "Windowed transfer not supported by node, using unsynchronized transfer"
+        )
+        await client.prepare_upgrade(image, len(binary), timeout=prepare_timeout)
+        await client.program_transfer(binary, att_mtu, progress)
+        return
+
+    await client.program_transfer_windowed(binary, params, att_mtu, progress)

--- a/src/anura/avss/protocol.py
+++ b/src/anura/avss/protocol.py
@@ -44,6 +44,8 @@ class OpCode(IntEnum):
     APPLY_UPGRADE = 101
     CONFIRM_UPGRADE = 102
     REBOOT = 103
+    PREPARE_UPGRADE_V2 = 104
+    PREPARE_UPGRADE_V2_RESPONSE = 105
 
     @staticmethod
     def _safe_name(value: int) -> str:

--- a/src/anura/avss/settings.py
+++ b/src/anura/avss/settings.py
@@ -29,7 +29,9 @@ class SettingsMapper:
         "aggregates_param_enable_32_63": 23,
     }
 
-    reverse_map: ClassVar[dict[int, str]] = {key: name for name, key in forward_map.items()}
+    reverse_map: ClassVar[dict[int, str]] = {
+        key: name for name, key in forward_map.items()
+    }
 
     @staticmethod
     def from_readable(settings):

--- a/tests/test_avss_program.py
+++ b/tests/test_avss_program.py
@@ -381,7 +381,8 @@ def test_windowed_transfer_different_image_restarts():
     assert bytes(transport.received) == binary_b
 
 
-def test_legacy_fallback_transfer_completes():
+def test_legacy_fallback_transfer_completes(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_LEGACY_SETTLE_TIMEOUT", 0.05)
     binary = make_binary(5 * CHUNK + 3)
     transport = FakeSensorTransport(len(binary), windowed_supported=False)
     client = AVSSClient(transport)
@@ -393,3 +394,34 @@ def test_legacy_fallback_transfer_completes():
     assert not transport.windowed
     assert bytes(transport.received) == binary
     assert progress[-1] == len(binary)
+
+
+def test_legacy_transfer_recovers_from_late_nack(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_LEGACY_SETTLE_TIMEOUT", 0.05)
+    binary = make_binary(6 * CHUNK)
+    transport = FakeSensorTransport(len(binary), windowed_supported=False)
+    # Drop the second-to-last chunk: the NACK it provokes is only generated
+    # by the final write, after which the old client stopped listening and
+    # proceeded to apply an incomplete transfer.
+    transport.drop_chunks = {5}
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+
+
+def test_legacy_transfer_recovers_from_dropped_final_chunk(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_LEGACY_SETTLE_TIMEOUT", 0.05)
+    binary = make_binary(6 * CHUNK)
+    transport = FakeSensorTransport(len(binary), windowed_supported=False)
+    # Drop the final chunk: no NACK is ever generated, so only the
+    # completion probe can heal the transfer.
+    transport.drop_chunks = {6}
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary

--- a/tests/test_avss_program.py
+++ b/tests/test_avss_program.py
@@ -1,0 +1,395 @@
+"""Tests for the Program characteristic firmware transfer loops."""
+
+import asyncio
+import hashlib
+import struct
+
+import cbor2
+import pytest
+
+from anura.avss.client import PROGRAM_OFFSET_ABORT, AVSSClient
+from anura.avss.exceptions import AVSSProgramTransferError
+from anura.avss.protocol import OpCode, ResponseCode
+from anura.avss.transport.base import AVSSTransport
+
+
+class FakeSensorTransport(AVSSTransport):
+    """Emulates the sensor side of the Program characteristic.
+
+    Mirrors the firmware behaviour of avss_dfu.c: in-order chunk acceptance,
+    a chunk-credit receive window, periodic ack notifications, rewind
+    requests repeating the last acked offset, single recovery acks for
+    duplicate bursts, repetition of the final ack for writes into a
+    completed transfer, and resumption of a matching interrupted transfer.
+    """
+
+    def __init__(
+        self,
+        image_size,
+        *,
+        max_chunk=252,
+        window_chunks=7,
+        ack_interval=3,
+        windowed_supported=True,
+        strict_window=True,
+    ):
+        self.image_size = image_size
+        self.max_chunk = max_chunk
+        self.window_chunks = window_chunks
+        self.ack_interval = ack_interval
+        self.windowed_supported = windowed_supported
+        # Enforce the client's outstanding-chunk discipline. Only valid in
+        # fault-free runs: after injected drops the bookkeeping of this
+        # emulation double-counts rewound writes.
+        self.strict_window = strict_window
+
+        self.received = bytearray(image_size)
+        self.expected = 0
+        self.digest = None
+        self.prepared_image = None
+        self.last_acked = 0
+        self.unacked_chunks = 0
+        self.resync = False
+        self.dup_acked = False
+        self.ready = False
+        self.aborted = False
+        self.windowed = False
+        self.resumed_from: int | None = None
+
+        # Fault injection
+        self.drop_chunks: set[int] = set()  # write numbers to drop (overrun)
+        self.drop_acks: set[int] = set()  # ack numbers to drop (lost notify)
+        self.abort_at_write: int | None = None
+
+        # Bookkeeping for assertions
+        self.write_count = 0
+        self.ack_count = 0
+        self.delivered_acked = 0
+        self.pending_ends: list[int] = []
+        self.payload_sizes: list[int] = []
+
+        self._program_cb = None
+
+    async def open(self):
+        pass
+
+    async def close(self):
+        pass
+
+    def set_report_callback(self, callback):
+        pass
+
+    def set_program_callback(self, callback):
+        self._program_cb = callback
+
+    def set_closed_callback(self, callback):
+        pass
+
+    def _notify(self, acked, window):
+        self.ack_count += 1
+        if self.ack_count not in self.drop_acks:
+            self.delivered_acked = max(self.delivered_acked, acked)
+            self._program_cb(struct.pack("<LB", acked, window))
+
+    def _send_ack(self):
+        # last_acked is updated even when the notification is dropped,
+        # like the firmware which ignores notify errors.
+        self.last_acked = self.expected
+        self.unacked_chunks = 0
+        self._notify(self.expected, self.window_chunks)
+
+    def _fresh_prepare(self, image, digest):
+        self.prepared_image = image
+        self.digest = digest
+        self.received = bytearray(self.image_size)
+        self.expected = 0
+        self.last_acked = 0
+        self.unacked_chunks = 0
+        self.resync = False
+        self.dup_acked = False
+        self.ready = False
+        self.aborted = False
+        self.delivered_acked = 0
+        self.pending_ends = []
+
+    async def control_point_request(self, req):
+        opcode = req[0]
+        args = cbor2.loads(req[1:])
+        if opcode == OpCode.PREPARE_UPGRADE_V2:
+            if not self.windowed_supported:
+                return bytes([OpCode.RESPONSE, opcode, ResponseCode.OPCODE_UNSUPPORTED])
+            assert args[1] == self.image_size
+            assert len(args[2]) == 32
+            resume = (
+                self.digest == args[2]
+                and self.prepared_image == args[0]
+                and not self.aborted
+            )
+            if resume:
+                self.resumed_from = self.expected
+                self.last_acked = self.expected
+                self.unacked_chunks = 0
+                self.resync = False
+                self.dup_acked = False
+                self.delivered_acked = 0
+                self.pending_ends = []
+            else:
+                self.resumed_from = None
+                self._fresh_prepare(args[0], args[2])
+            self.windowed = True
+            self._send_ack()  # initial window grant
+            return bytes([OpCode.PREPARE_UPGRADE_V2_RESPONSE]) + cbor2.dumps(
+                {0: self.max_chunk, 1: self.window_chunks, 2: self.expected}
+            )
+        if opcode == OpCode.PREPARE_UPGRADE:
+            assert args[1] == self.image_size
+            self._fresh_prepare(args[0], None)
+            self.windowed = False
+            return bytes([OpCode.RESPONSE, opcode, ResponseCode.OK])
+        raise AssertionError(f"unexpected opcode {opcode}")
+
+    async def program_write(self, value):
+        self.write_count += 1
+        (offset,) = struct.unpack("<L", value[:4])
+        payload = value[4:]
+        self.payload_sizes.append(len(payload))
+        assert len(payload) <= self.max_chunk
+
+        if self.aborted:
+            return
+
+        if self.abort_at_write == self.write_count:
+            self.aborted = True
+            self._program_cb(struct.pack("<LB", PROGRAM_OFFSET_ABORT, 0))
+            return
+
+        if self.ready:
+            # Retransmission into a completed transfer: repeat the final ack.
+            if self.windowed and not self.dup_acked:
+                self.dup_acked = True
+                self._notify(self.image_size, self.window_chunks)
+            return
+
+        if self.windowed and self.strict_window:
+            self.pending_ends = [
+                e for e in self.pending_ends if e > self.delivered_acked
+            ]
+            self.pending_ends.append(offset + len(payload))
+            assert len(self.pending_ends) <= self.window_chunks
+
+        if self.write_count in self.drop_chunks:
+            return
+
+        if not self.windowed:
+            # Legacy: NACK the expected offset on mismatch.
+            if offset != self.expected:
+                self._program_cb(struct.pack("<L", self.expected))
+                return
+        else:
+            if offset < self.expected:
+                if not self.resync and not self.dup_acked:
+                    self.dup_acked = True
+                    self._send_ack()
+                return
+            if offset > self.expected:
+                if not self.resync:
+                    self.resync = True
+                    self._notify(self.last_acked, self.window_chunks)
+                return
+
+        self.resync = False
+        self.dup_acked = False
+        self.received[offset : offset + len(payload)] = payload
+        self.expected += len(payload)
+        self.unacked_chunks += 1
+        if self.expected == self.image_size:
+            self.ready = True
+        if self.windowed and (self.ready or self.unacked_chunks >= self.ack_interval):
+            self._send_ack()
+
+
+def run(coro):
+    return asyncio.run(asyncio.wait_for(coro, timeout=30))
+
+
+def make_binary(size):
+    return bytes(i & 0xFF for i in range(size))
+
+
+ATT_MTU = 243
+CHUNK = (ATT_MTU - 3) - 4
+
+
+def test_windowed_transfer_completes():
+    binary = make_binary(10 * CHUNK + 17)
+    transport = FakeSensorTransport(len(binary))
+    client = AVSSClient(transport)
+    progress = []
+
+    run(client.program_transfer(binary, image=0, progress=progress.append))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+    assert transport.prepared_image == 0
+    assert transport.digest == hashlib.sha256(binary).digest()
+    assert progress[-1] == len(binary)
+    assert progress == sorted(progress)
+    # No retransmissions needed on a clean transfer.
+    assert transport.write_count == 11
+
+
+def test_windowed_transfer_respects_max_chunk():
+    binary = make_binary(1000)
+    transport = FakeSensorTransport(len(binary), max_chunk=100)
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+    assert max(transport.payload_sizes) <= 100
+
+
+def test_windowed_transfer_single_chunk():
+    binary = make_binary(10)
+    transport = FakeSensorTransport(len(binary))
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+
+
+def test_windowed_transfer_recovers_from_dropped_chunk():
+    binary = make_binary(20 * CHUNK)
+    transport = FakeSensorTransport(len(binary), strict_window=False)
+    transport.drop_chunks = {5}
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+    assert transport.write_count > 20
+
+
+def test_windowed_transfer_recovers_from_lost_ack(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_STALL_TIMEOUT", 0.05)
+    binary = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary), strict_window=False)
+    # Ack 1 is the initial window grant; drop a mid-transfer ack.
+    transport.drop_acks = {3}
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+
+
+def test_windowed_transfer_recovers_from_lost_final_ack(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_STALL_TIMEOUT", 0.05)
+    binary = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary), strict_window=False)
+    # With an ack interval of 3 chunks: initial grant, acks after chunks
+    # 3, 6 and 9, then the final ack after chunk 10 is ack number 5.
+    transport.drop_acks = {5}
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+
+    assert transport.ready
+    assert bytes(transport.received) == binary
+
+
+def test_windowed_transfer_aborted_by_node():
+    binary = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary))
+    transport.abort_at_write = 4
+    client = AVSSClient(transport)
+
+    with pytest.raises(AVSSProgramTransferError):
+        run(client.program_transfer(binary, image=0))
+
+
+def test_windowed_transfer_fails_on_persistent_stall(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_STALL_TIMEOUT", 0.01)
+    binary = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary), strict_window=False)
+    # Drop every notification after the initial grant.
+    transport.drop_acks = set(range(2, 10_000))
+    client = AVSSClient(transport)
+
+    with pytest.raises(AVSSProgramTransferError):
+        run(client.program_transfer(binary, image=0))
+
+
+def test_windowed_transfer_resumes_after_interruption(monkeypatch):
+    monkeypatch.setattr("anura.avss.client.PROGRAM_STALL_TIMEOUT", 0.01)
+    binary = make_binary(40 * CHUNK)
+    transport = FakeSensorTransport(len(binary), strict_window=False)
+    client = AVSSClient(transport)
+
+    # First attempt is starved of feedback and fails with partial progress.
+    transport.drop_acks = set(range(2, 10_000))
+    with pytest.raises(AVSSProgramTransferError):
+        run(client.program_transfer(binary, image=0))
+    committed = transport.expected
+    assert 0 < committed < len(binary)
+
+    # Second attempt resumes from the committed offset.
+    transport.drop_acks = set()
+    progress = []
+    run(client.program_transfer(binary, image=0, progress=progress.append))
+
+    assert transport.resumed_from == committed
+    assert transport.ready
+    assert bytes(transport.received) == binary
+    # The resumed transfer starts progress reporting at the resume offset.
+    assert progress[0] == committed
+
+
+def test_windowed_transfer_resume_of_complete_transfer():
+    binary = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary))
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary, image=0))
+    writes = transport.write_count
+
+    progress = []
+    run(client.program_transfer(binary, image=0, progress=progress.append))
+
+    assert transport.resumed_from == len(binary)
+    assert transport.write_count == writes  # nothing retransmitted
+    assert progress == [len(binary)]
+
+
+def test_windowed_transfer_different_image_restarts():
+    binary_a = make_binary(10 * CHUNK)
+    transport = FakeSensorTransport(len(binary_a))
+    client = AVSSClient(transport)
+
+    run(client.program_transfer(binary_a, image=0))
+
+    binary_b = bytes(reversed(binary_a))
+    run(client.program_transfer(binary_b, image=0))
+
+    assert transport.resumed_from is None  # fresh prepare, not a resume
+    assert transport.ready
+    assert bytes(transport.received) == binary_b
+
+
+def test_legacy_fallback_transfer_completes():
+    binary = make_binary(5 * CHUNK + 3)
+    transport = FakeSensorTransport(len(binary), windowed_supported=False)
+    client = AVSSClient(transport)
+    progress = []
+
+    run(client.program_transfer(binary, image=0, progress=progress.append))
+
+    assert transport.ready
+    assert not transport.windowed
+    assert bytes(transport.received) == binary
+    assert progress[-1] == len(binary)

--- a/tests/test_avss_program.py
+++ b/tests/test_avss_program.py
@@ -7,6 +7,7 @@ import struct
 import cbor2
 import pytest
 
+from anura.avss import procedures
 from anura.avss.client import PROGRAM_OFFSET_ABORT, AVSSClient
 from anura.avss.exceptions import AVSSProgramTransferError
 from anura.avss.protocol import OpCode, ResponseCode
@@ -226,7 +227,7 @@ def test_windowed_transfer_completes():
     client = AVSSClient(transport)
     progress = []
 
-    run(client.program_transfer(binary, image=0, progress=progress.append))
+    run(procedures.upload_firmware(client, binary, image=0, progress=progress.append))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -243,7 +244,7 @@ def test_windowed_transfer_respects_max_chunk():
     transport = FakeSensorTransport(len(binary), max_chunk=100)
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -255,7 +256,7 @@ def test_windowed_transfer_single_chunk():
     transport = FakeSensorTransport(len(binary))
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -267,7 +268,7 @@ def test_windowed_transfer_recovers_from_dropped_chunk():
     transport.drop_chunks = {5}
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -282,7 +283,7 @@ def test_windowed_transfer_recovers_from_lost_ack(monkeypatch):
     transport.drop_acks = {3}
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -297,7 +298,7 @@ def test_windowed_transfer_recovers_from_lost_final_ack(monkeypatch):
     transport.drop_acks = {5}
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -310,7 +311,7 @@ def test_windowed_transfer_aborted_by_node():
     client = AVSSClient(transport)
 
     with pytest.raises(AVSSProgramTransferError):
-        run(client.program_transfer(binary, image=0))
+        run(procedures.upload_firmware(client, binary, image=0))
 
 
 def test_windowed_transfer_fails_on_persistent_stall(monkeypatch):
@@ -322,7 +323,7 @@ def test_windowed_transfer_fails_on_persistent_stall(monkeypatch):
     client = AVSSClient(transport)
 
     with pytest.raises(AVSSProgramTransferError):
-        run(client.program_transfer(binary, image=0))
+        run(procedures.upload_firmware(client, binary, image=0))
 
 
 def test_windowed_transfer_resumes_after_interruption(monkeypatch):
@@ -334,14 +335,14 @@ def test_windowed_transfer_resumes_after_interruption(monkeypatch):
     # First attempt is starved of feedback and fails with partial progress.
     transport.drop_acks = set(range(2, 10_000))
     with pytest.raises(AVSSProgramTransferError):
-        run(client.program_transfer(binary, image=0))
+        run(procedures.upload_firmware(client, binary, image=0))
     committed = transport.expected
     assert 0 < committed < len(binary)
 
     # Second attempt resumes from the committed offset.
     transport.drop_acks = set()
     progress = []
-    run(client.program_transfer(binary, image=0, progress=progress.append))
+    run(procedures.upload_firmware(client, binary, image=0, progress=progress.append))
 
     assert transport.resumed_from == committed
     assert transport.ready
@@ -355,11 +356,11 @@ def test_windowed_transfer_resume_of_complete_transfer():
     transport = FakeSensorTransport(len(binary))
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
     writes = transport.write_count
 
     progress = []
-    run(client.program_transfer(binary, image=0, progress=progress.append))
+    run(procedures.upload_firmware(client, binary, image=0, progress=progress.append))
 
     assert transport.resumed_from == len(binary)
     assert transport.write_count == writes  # nothing retransmitted
@@ -371,10 +372,10 @@ def test_windowed_transfer_different_image_restarts():
     transport = FakeSensorTransport(len(binary_a))
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary_a, image=0))
+    run(procedures.upload_firmware(client, binary_a, image=0))
 
     binary_b = bytes(reversed(binary_a))
-    run(client.program_transfer(binary_b, image=0))
+    run(procedures.upload_firmware(client, binary_b, image=0))
 
     assert transport.resumed_from is None  # fresh prepare, not a resume
     assert transport.ready
@@ -388,7 +389,7 @@ def test_legacy_fallback_transfer_completes(monkeypatch):
     client = AVSSClient(transport)
     progress = []
 
-    run(client.program_transfer(binary, image=0, progress=progress.append))
+    run(procedures.upload_firmware(client, binary, image=0, progress=progress.append))
 
     assert transport.ready
     assert not transport.windowed
@@ -406,7 +407,7 @@ def test_legacy_transfer_recovers_from_late_nack(monkeypatch):
     transport.drop_chunks = {5}
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
@@ -421,7 +422,28 @@ def test_legacy_transfer_recovers_from_dropped_final_chunk(monkeypatch):
     transport.drop_chunks = {6}
     client = AVSSClient(transport)
 
-    run(client.program_transfer(binary, image=0))
+    run(procedures.upload_firmware(client, binary, image=0))
 
     assert transport.ready
     assert bytes(transport.received) == binary
+
+
+def test_program_transfer_keeps_1_0_contract(monkeypatch):
+    # The 1.0 calling convention: prepare_upgrade followed by
+    # program_transfer with its original signature.
+    monkeypatch.setattr("anura.avss.client.PROGRAM_LEGACY_SETTLE_TIMEOUT", 0.05)
+    binary = make_binary(4 * CHUNK + 9)
+    transport = FakeSensorTransport(len(binary))
+    client = AVSSClient(transport)
+    progress = []
+
+    async def flow():
+        await client.prepare_upgrade(0, len(binary))
+        await client.program_transfer(binary, 243, progress.append)
+
+    run(flow())
+
+    assert transport.ready
+    assert not transport.windowed
+    assert bytes(transport.received) == binary
+    assert progress[-1] == len(binary)


### PR DESCRIPTION
## Summary

Client-side support for the AVSS windowed DFU transfer introduced in ReVibe-Energy/anura#564, plus robustness fixes for the legacy transfer.

Layering: `AVSSClient` stays a one-to-one protocol wrapper, and multi-step transactions live in a new high-level module, `anura.avss.procedures` — the precedent for future combos such as a full settings replacement.

- **Low-level** (`AVSSClient`):
  - `prepare_upgrade_v2` — combined prepare + flow-control negotiation; the response carries the max chunk size, the chunk-credit window, and the offset to resume an interrupted transfer of the same image (identity = SHA-256 digest).
  - `program_transfer_windowed` — the windowed transfer loop, driven by the `prepare_upgrade_v2` response: chunks stream while no more than the granted window of writes is outstanding, with go-back-N recovery.
  - `program_transfer` — **unchanged 1.0 signature and contract** (prepare first, unsynchronized transfer), now hardened: completion is confirmed by NACK silence plus a final-chunk probe, fixing the fleet failure where Apply Upgrade ran against an incomplete transfer.
- **High-level** (`anura.avss.procedures`):
  - `upload_firmware(client, binary, image=...)` — prepares and uploads in one call, windowed with resume when the node supports it, legacy fallback otherwise. `pyanura-cli`'s `avss upgrade` uses it.
- Fix: `AVSSControlPointError.from_response` raised `TypeError` instead of the proper AVSS exception for any device error response on Python 3.11.

## Testing

- Fault-injecting sensor emulation in the test suite (24 tests): window discipline, lost mid/final acks, rewind, abort, resume (interrupted / already-complete / different-image), legacy late-NACK and dropped-final-chunk recovery, and a 1.0 calling-convention regression test.
- On a VS1 over BLE (pre-restructure equivalent code paths): legacy fallback against pre-windowed firmware (full OTA cycle), fielded 1.0rc1 client against new firmware, windowed transfer (~3x legacy throughput), mid-transfer disconnect + resume, instant READY resume, recovery from a forcibly dropped chunk, apply + confirm + boot.
