### PR TITLE
avss: coerce settings to firmware wire types in SettingsMapper

### DIFF
--- a/src/anura/avss/settings.py
+++ b/src/anura/avss/settings.py
@@ -1,4 +1,13 @@
+import enum
 from typing import ClassVar
+
+
+class SettingType(enum.Enum):
+    """The CBOR type the node firmware expects for a setting value."""
+
+    UINT = enum.auto()
+    FLOAT = enum.auto()
+    BOOL = enum.auto()
 
 
 class SettingsMapper:
@@ -33,6 +42,75 @@ class SettingsMapper:
         key: name for name, key in forward_map.items()
     }
 
+    # The wire type per setting, kept in lockstep with the AVSS protocol
+    # and firmware implemenations. Every name in forward_map must appear here.
+    types: ClassVar[dict[str, SettingType]] = {
+        "base_sample_rate_hz": SettingType.UINT,
+        "snippet_interval_ms": SettingType.UINT,
+        "snippet_length": SettingType.UINT,
+        "health_interval_ms": SettingType.UINT,
+        "base_axis_enable": SettingType.UINT,
+        "motion_threshold_rms_g": SettingType.FLOAT,
+        "motion_standby_delay_ms": SettingType.UINT,
+        "wom_sample_rate_hz": SettingType.UINT,
+        "wom_threshold_g": SettingType.FLOAT,
+        "snippet_mode": SettingType.UINT,
+        "capture_mode": SettingType.UINT,
+        "capture_buffer_length": SettingType.UINT,
+        "events_motion_start_enable": SettingType.BOOL,
+        "events_motion_start_capture": SettingType.BOOL,
+        "events_motion_start_capture_duration_ms": SettingType.UINT,
+        "aggregates_mode": SettingType.UINT,
+        "aggregates_interval_ms": SettingType.UINT,
+        "aggregates_sample_rate_hz": SettingType.UINT,
+        "aggregates_hpf_mode": SettingType.UINT,
+        "aggregates_hpf_cutoff": SettingType.FLOAT,
+        "aggregates_fft_mode": SettingType.UINT,
+        "aggregates_fft_length": SettingType.UINT,
+        "aggregates_param_enable_0_31": SettingType.UINT,
+        "aggregates_param_enable_32_63": SettingType.UINT,
+    }
+
+    @staticmethod
+    def _coerce(name, value):
+        """Coerce value to the CBOR type the firmware expects for setting name.
+
+        Settings with no known type (e.g. a raw integer key not in
+        forward_map) pass through unchanged.
+        """
+        setting_type = SettingsMapper.types.get(name)
+        if setting_type is SettingType.BOOL and not isinstance(value, bool):
+            raise TypeError(f"setting {name!r} expects a bool, got {type(value)!r}")
+        # bool is a subclass of int, so guard against it explicitly: only
+        # int<->float coerce, never bool<->numeric in either direction.
+        if setting_type is SettingType.FLOAT:
+            if isinstance(value, bool):
+                raise TypeError(
+                    f"setting {name!r} expects a float, got {type(value)!r}"
+                )
+            if isinstance(value, int):
+                return float(value)
+            elif isinstance(value, float):
+                return value
+            else:
+                raise TypeError(
+                    f"setting {name!r} expects a float, got {type(value)!r}"
+                )
+        if setting_type is SettingType.UINT:
+            if isinstance(value, bool):
+                raise TypeError(f"setting {name!r} expects an int, got {type(value)!r}")
+            if isinstance(value, float):
+                if not value.is_integer():
+                    raise ValueError(
+                        f"setting {name!r} expects an integer, got {value!r}"
+                    )
+                return int(value)
+            elif isinstance(value, int):
+                return value
+            else:
+                raise TypeError(f"setting {name!r} expects an int, got {type(value)!r}")
+        return value
+
     @staticmethod
     def from_readable(settings):
         def map_key(key):
@@ -44,7 +122,12 @@ class SettingsMapper:
                 except ValueError:
                     raise ValueError(f"Invalid key {key}") from None
 
-        return {map_key(k): v for k, v in settings.items()}
+        result = {}
+        for key, value in settings.items():
+            key_id = map_key(key)
+            name = SettingsMapper.reverse_map.get(key_id)
+            result[key_id] = SettingsMapper._coerce(name, value)
+        return result
 
     @staticmethod
     def to_readable(settings):

--- a/tests/test_settings_mapper.py
+++ b/tests/test_settings_mapper.py
@@ -1,0 +1,79 @@
+"""Tests for SettingsMapper value coercion to firmware wire types."""
+
+import cbor2
+import pytest
+
+from anura.avss.settings import SettingsMapper, SettingType
+
+
+def test_types_cover_every_setting():
+    # The type table must stay in lockstep with forward_map so no setting is
+    # ever sent without a known wire type.
+    assert set(SettingsMapper.types) == set(SettingsMapper.forward_map)
+
+
+def test_integral_float_coerced_to_uint():
+    result = SettingsMapper.from_readable(
+        {"base_sample_rate_hz": 2048.0, "snippet_length": 3096.0}
+    )
+
+    assert result == {0: 2048, 2: 3096}
+    assert all(type(v) is int for v in result.values())
+
+
+def test_int_coerced_to_float_setting():
+    result = SettingsMapper.from_readable({"wom_threshold_g": 1})
+
+    assert result == {8: 1.0}
+    assert type(result[8]) is float
+    assert type(cbor2.loads(cbor2.dumps(result))[8]) is float
+
+
+def test_non_integral_float_for_uint_rejected():
+    with pytest.raises(ValueError, match="expects an integer"):
+        SettingsMapper.from_readable({"snippet_length": 3096.5})
+
+
+def test_bool_rejected_for_uint_setting():
+    # bool is a subclass of int, but a bool must never be sent where the
+    # firmware expects a numeric type.
+    with pytest.raises(TypeError, match="expects an int"):
+        SettingsMapper.from_readable({"base_sample_rate_hz": True})
+
+
+def test_bool_rejected_for_float_setting():
+    with pytest.raises(TypeError, match="expects a float"):
+        SettingsMapper.from_readable({"wom_threshold_g": False})
+
+
+def test_int_rejected_for_bool_setting():
+    with pytest.raises(TypeError, match="expects a bool"):
+        SettingsMapper.from_readable({"events_motion_start_enable": 1})
+
+
+def test_float_rejected_for_bool_setting():
+    with pytest.raises(TypeError, match="expects a bool"):
+        SettingsMapper.from_readable({"events_motion_start_enable": 1.0})
+
+
+def test_bool_accepted_for_bool_setting():
+    result = SettingsMapper.from_readable(
+        {"events_motion_start_enable": True, "events_motion_start_capture": False}
+    )
+
+    assert result == {12: True, 13: False}
+    assert all(type(v) is bool for v in result.values())
+
+
+def test_unknown_key_passes_through_unchanged():
+    # A raw integer key not in forward_map has no known type and is left as-is.
+    assert SettingsMapper.from_readable({9999: 5.0}) == {9999: 5.0}
+
+
+def test_settings_type_is_exhaustive():
+    # Guard against adding a wire type without handling it in _coerce.
+    assert set(SettingType) == {
+        SettingType.UINT,
+        SettingType.FLOAT,
+        SettingType.BOOL,
+    }


### PR DESCRIPTION
SettingsMapper.from_readable now coerces every known setting to the CBOR type the firmware expects. Non-integral floats for integer settings raise rather than silently truncate; unknown keys pass through unchanged.