### PR TITLE
dfu: Support firmware bundles in the library and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `anura.dfu`: support for Anura firmware bundles —
-  `parse_bundle` reads a bundle zip (a `meta.json` manifest plus one image per
-  firmware component) into `Bundle`/`Component`/`Dependency`, with `Version`
-  and `VersionSet` for the device version format and dependency constraints.
+- `anura.dfu`, a new module for ANURA firmware bundles. `parse_bundle` reads
+  a bundle zip (a `meta.json` manifest plus one image per firmware component)
+  into `Bundle`/`Component`/`Dependency`, with `Version` and `VersionSet` for
+  the device version format and dependency constraints. `unmet_dependencies`
+  checks a component's or a bundle's dependencies against the firmware a
+  device reports, described by `InstalledComponent`, returning an
+  `UnmetDependency` per unsatisfied dependency.
 - The CLI `avss upgrade` and `transceiver upgrade` commands accept a firmware
   bundle as `--file` in addition to a raw image. Every component in the bundle
   is applied in order: dependencies are checked against the installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `anura.dfu`: support for Anura firmware bundles —
+  `parse_bundle` reads a bundle zip (a `meta.json` manifest plus one image per
+  firmware component) into `Bundle`/`Component`/`Dependency`, with `Version`
+  and `VersionSet` for the device version format and dependency constraints.
+- The CLI `avss upgrade` and `transceiver upgrade` commands accept a firmware
+  bundle as `--file` in addition to a raw image. Every component in the bundle
+  is applied in order: dependencies are checked against the installed
+  firmware, already-running components are skipped, and each upload is
+  applied, verified after the reboot and confirmed.
+
 ## [1.1.0]
 
 ### Added

--- a/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/avss_commands.py
@@ -1,10 +1,12 @@
 import asyncio
 import functools
+import io
 import json
 import logging
 import math
 import sys
 import time
+import zipfile
 from pathlib import Path
 
 import click
@@ -14,10 +16,12 @@ from bleak.exc import BleakError
 import anura.avss as avss
 from anura.avss import procedures
 from anura.avss.bleak_avss_client import BleakAVSSClient
+from anura.dfu import parse_bundle
 from anura.transceiver.client import TransceiverClient
 from anura.transceiver.models import BluetoothAddrLE
 from anura.transceiver.proxy_avss_client import ProxyAVSSClient
 
+from .bundle import BleakAVSSTarget, ProxyAVSSTarget, apply_bundle
 from .progress import upload_progress
 from .session import SessionFile
 
@@ -96,10 +100,17 @@ def scan():
     "--transceiver-port", default=7645, show_default=True, help="TCP port number"
 )
 @click.option("--address", help="Bluetooth address of AVSS node.", required=True)
-@click.option("--file", metavar="FILE", help="Path to firmware image.")
+@click.option(
+    "--file", metavar="FILE", help="Path to firmware image or firmware bundle (.zip)."
+)
 @click.option("--confirm-only", is_flag=True, help="Run only the confirm step.")
 def upgrade(transceiver, transceiver_port, address, file, confirm_only):
-    """Upgrade node firmware."""
+    """Upgrade node firmware.
+
+    FILE may be a raw firmware image or a firmware bundle (a .zip with a
+    meta.json manifest). With a bundle, every component in the bundle is
+    applied and confirmed in order.
+    """
 
     if not confirm_only and not file:
         click.echo(
@@ -108,6 +119,7 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
         )
         sys.exit(1)
 
+    bundle = None
     if not confirm_only:
         try:
             binary = Path(file).read_bytes()
@@ -115,7 +127,43 @@ def upgrade(transceiver, transceiver_port, address, file, confirm_only):
             click.echo(f"Error: {ex}", err=True)
             sys.exit(1)
 
+        if zipfile.is_zipfile(io.BytesIO(binary)):
+            try:
+                bundle = parse_bundle(binary)
+            except ValueError as ex:
+                click.echo(f"Error: {ex}", err=True)
+                sys.exit(1)
+
     address = BluetoothAddrLE.parse(address)
+
+    async def do_bundle_async():
+        try:
+            await apply_bundle(BleakAVSSTarget(address.address_str()), bundle)
+        except Exception as ex:
+            click.echo(f"Error: {ex}", err=True)
+            sys.exit(1)
+
+    async def do_bundle_proxy_async():
+        try:
+            logger.info(f"Connect to transceiver {transceiver}")
+            async with TransceiverClient(transceiver, transceiver_port) as trx_client:
+                # Check if the transceiver is assigned to the given node
+                resp = await trx_client.get_assigned_nodes()
+                if not any(node.address == address for node in resp.nodes):
+                    click.echo(f"Error: Transceiver not assigned to node {address}")
+                    sys.exit(1)
+
+                await apply_bundle(ProxyAVSSTarget(trx_client, address), bundle)
+        except Exception as ex:
+            click.echo(f"Error: {ex}", err=True)
+            sys.exit(1)
+
+    if bundle is not None:
+        if transceiver:
+            asyncio.run(do_bundle_proxy_async())
+        else:
+            asyncio.run(do_bundle_async())
+        return
 
     async def do_async():
         try:

--- a/packages/pyanura-cli/src/pyanura_cli/bundle.py
+++ b/packages/pyanura-cli/src/pyanura_cli/bundle.py
@@ -10,7 +10,6 @@ import asyncio
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
-from dataclasses import dataclass
 from typing import Protocol
 
 import click
@@ -20,7 +19,15 @@ from anura.avss import procedures
 from anura.avss.bleak_avss_client import BleakAVSSClient
 from anura.avss.client import AVSSClient
 from anura.avss.exceptions import AVSSOpCodeUnsupportedError
-from anura.dfu import Bundle, Component, Dependency, Version, total_dependencies
+from anura.dfu import (
+    Bundle,
+    Component,
+    Dependency,
+    InstalledComponent,
+    Version,
+    total_dependencies,
+    unmet_dependencies,
+)
 from anura.transceiver.client import TransceiverClient
 from anura.transceiver.exceptions import TransceiverError
 from anura.transceiver.models import BluetoothAddrLE
@@ -29,12 +36,6 @@ from anura.transceiver.proxy_avss_client import ProxyAVSSClient
 from .progress import upload_progress
 
 RECONNECT_TIMEOUT = 60.0
-
-
-@dataclass
-class InstalledComponent:
-    version: Version | None
-    build: str | None
 
 
 class BundleSession(Protocol):
@@ -220,18 +221,8 @@ class TransceiverTarget:
 def _check_dependencies(
     dependencies: list[Dependency], installed: dict[str, InstalledComponent]
 ) -> None:
-    for dep in dependencies:
-        current = installed.get(dep.name)
-        if current is None or current.version is None:
-            raise RuntimeError(
-                f"Cannot verify dependency on '{dep.name}' version {dep.version}: "
-                f"installed '{dep.name}' version is unknown"
-            )
-        if current.version not in dep.version:
-            raise RuntimeError(
-                f"Dependency not met: requires '{dep.name}' version {dep.version}, "
-                f"device reports {current.version}"
-            )
+    if unmet := unmet_dependencies(dependencies, installed):
+        raise RuntimeError("Dependency not met: " + "; ".join(str(u) for u in unmet))
 
 
 async def apply_bundle(target: BundleTarget, bundle: Bundle) -> None:

--- a/packages/pyanura-cli/src/pyanura_cli/bundle.py
+++ b/packages/pyanura-cli/src/pyanura_cli/bundle.py
@@ -1,0 +1,290 @@
+"""Applying DFU bundles to AVSS nodes and transceivers.
+
+For each component in the bundle, in order — check its dependencies against
+the installed firmware, skip straight to confirmation if the component is
+already running, otherwise upload, apply, wait for the device to reboot into
+the new image, verify that the image was not reverted, and confirm it.
+"""
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
+from typing import Protocol
+
+import click
+from bleak import BleakScanner
+
+from anura.avss import procedures
+from anura.avss.bleak_avss_client import BleakAVSSClient
+from anura.avss.client import AVSSClient
+from anura.avss.exceptions import AVSSOpCodeUnsupportedError
+from anura.dfu import Bundle, Component, Dependency, Version, total_dependencies
+from anura.transceiver.client import TransceiverClient
+from anura.transceiver.exceptions import TransceiverError
+from anura.transceiver.models import BluetoothAddrLE
+from anura.transceiver.proxy_avss_client import ProxyAVSSClient
+
+from .progress import upload_progress
+
+RECONNECT_TIMEOUT = 60.0
+
+
+@dataclass
+class InstalledComponent:
+    version: Version | None
+    build: str | None
+
+
+class BundleSession(Protocol):
+    """Bundle operations on a connected device."""
+
+    async def installed(self) -> dict[str, InstalledComponent]: ...
+
+    async def upload(
+        self, component: Component, progress: Callable[[int], None]
+    ) -> None: ...
+
+    async def apply(self) -> None: ...
+
+    async def confirm(self) -> None: ...
+
+
+class BundleTarget(Protocol):
+    """A device that bundles can be applied to, reconnectable across reboots."""
+
+    def connect(self) -> AbstractAsyncContextManager[BundleSession]: ...
+
+    async def wait_reboot(self) -> None: ...
+
+
+class AVSSBundleSession:
+    def __init__(self, client: AVSSClient):
+        self._client = client
+
+    async def installed(self) -> dict[str, InstalledComponent]:
+        try:
+            info = await self._client.get_firmware_info()
+        except AVSSOpCodeUnsupportedError:
+            # Firmware too old to support Get Firmware Info: only the app
+            # version is available and the net image is unknown.
+            version_info = await self._client.get_version()
+            return {
+                "app": InstalledComponent(
+                    version=Version.from_string(version_info.version),
+                    build=version_info.build_version,
+                ),
+            }
+        return {
+            "app": InstalledComponent(
+                version=Version.from_numeric(info.app_version),
+                build=info.app_build_version,
+            ),
+            "net": InstalledComponent(
+                version=Version.from_numeric(info.net_version),
+                build=info.net_build_version,
+            ),
+        }
+
+    async def upload(
+        self, component: Component, progress: Callable[[int], None]
+    ) -> None:
+        await procedures.upload_firmware(
+            self._client, component.contents, image=0, progress=progress
+        )
+
+    async def apply(self) -> None:
+        await self._client.apply_upgrade()
+
+    async def confirm(self) -> None:
+        await self._client.confirm_upgrade(0)
+
+
+class BleakAVSSTarget:
+    """An AVSS node reached over a direct Bluetooth connection."""
+
+    def __init__(self, address: str):
+        self._address = address
+
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[AVSSBundleSession]:
+        device = await BleakScanner.find_device_by_address(
+            self._address, timeout=RECONNECT_TIMEOUT
+        )
+        if device is None:
+            raise RuntimeError(f"Node {self._address} not found")
+        async with BleakAVSSClient(device) as client:
+            yield AVSSBundleSession(client)
+
+    async def wait_reboot(self) -> None:
+        # Wait at least 5 seconds to make sure we don't find the device
+        # before it has actually rebooted and started swapping images.
+        await asyncio.sleep(5.0)
+
+
+class ProxyAVSSTarget:
+    """An AVSS node reached through a connected transceiver."""
+
+    def __init__(self, transceiver: TransceiverClient, address: BluetoothAddrLE):
+        self._transceiver = transceiver
+        self._address = address
+
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[AVSSBundleSession]:
+        # The node may not have reconnected to the transceiver yet;
+        # retry until it answers.
+        deadline = time.monotonic() + RECONNECT_TIMEOUT
+        while True:
+            stack = AsyncExitStack()
+            try:
+                client = await stack.enter_async_context(
+                    ProxyAVSSClient(self._transceiver, self._address)
+                )
+                await client.get_version()
+                break
+            except Exception:
+                await stack.aclose()
+                if time.monotonic() >= deadline:
+                    raise
+                await asyncio.sleep(1.0)
+        async with stack:
+            yield AVSSBundleSession(client)
+
+    async def wait_reboot(self) -> None:
+        await asyncio.sleep(30.0)
+
+
+class TransceiverBundleSession:
+    def __init__(self, client: TransceiverClient):
+        self._client = client
+
+    async def installed(self) -> dict[str, InstalledComponent]:
+        info = await self._client.get_firmware_info()
+        return {
+            "app": InstalledComponent(
+                version=Version.from_numeric(info.app_version),
+                build=info.app_build_version,
+            ),
+            "net": InstalledComponent(
+                version=Version.from_numeric(info.net_version),
+                build=info.net_build_version,
+            ),
+        }
+
+    async def upload(
+        self, component: Component, progress: Callable[[int], None]
+    ) -> None:
+        await self._client.dfu_prepare(size=len(component.contents))
+        await self._client.dfu_write_image(component.contents, progress=progress)
+
+    async def apply(self) -> None:
+        await self._client.dfu_apply()
+
+    async def confirm(self) -> None:
+        await self._client.dfu_confirm()
+
+
+class TransceiverTarget:
+    """A transceiver reached over TCP or USB."""
+
+    def __init__(self, host: str, port: int):
+        self._host = host
+        self._port = port
+
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[TransceiverBundleSession]:
+        # The transceiver may still be rebooting; retry until it answers.
+        deadline = time.monotonic() + RECONNECT_TIMEOUT
+        while True:
+            stack = AsyncExitStack()
+            try:
+                client = await stack.enter_async_context(
+                    TransceiverClient(self._host, self._port)
+                )
+                break
+            except (TimeoutError, OSError, TransceiverError):
+                await stack.aclose()
+                if time.monotonic() >= deadline:
+                    raise
+                await asyncio.sleep(1.0)
+        async with stack:
+            yield TransceiverBundleSession(client)
+
+    async def wait_reboot(self) -> None:
+        # Wait at least 5 seconds to make sure we don't reconnect before the
+        # device has actually rebooted and started swapping images.
+        await asyncio.sleep(5.0)
+
+
+def _check_dependencies(
+    dependencies: list[Dependency], installed: dict[str, InstalledComponent]
+) -> None:
+    for dep in dependencies:
+        current = installed.get(dep.name)
+        if current is None or current.version is None:
+            raise RuntimeError(
+                f"Cannot verify dependency on '{dep.name}' version {dep.version}: "
+                f"installed '{dep.name}' version is unknown"
+            )
+        if current.version not in dep.version:
+            raise RuntimeError(
+                f"Dependency not met: requires '{dep.name}' version {dep.version}, "
+                f"device reports {current.version}"
+            )
+
+
+async def apply_bundle(target: BundleTarget, bundle: Bundle) -> None:
+    """Apply every component of a firmware bundle to a device, in order."""
+    if not bundle.components:
+        raise RuntimeError("Bundle contains no firmware components")
+
+    checked_bundle_dependencies = False
+
+    for component in bundle.components:
+        async with target.connect() as session:
+            installed = await session.installed()
+
+            if not checked_bundle_dependencies:
+                _check_dependencies(total_dependencies(bundle.components), installed)
+                checked_bundle_dependencies = True
+
+            current = installed.get(component.name)
+            if current is not None and component.matches_installed(
+                current.version, current.build
+            ):
+                click.echo(
+                    f"Component '{component.name}' is already running "
+                    f"{component.version}, confirming"
+                )
+                await session.confirm()
+                continue
+
+            _check_dependencies(component.dependencies, installed)
+
+            with upload_progress(
+                len(component.contents),
+                f"Uploading '{component.name}' {component.version}",
+            ) as on_progress:
+                await session.upload(component, on_progress)
+            await session.apply()
+
+        click.echo("Waiting for device to reboot with new firmware image...")
+        await target.wait_reboot()
+
+        async with target.connect() as session:
+            installed = await session.installed()
+            current = installed.get(component.name)
+            if current is None or not component.matches_installed(
+                current.version, current.build
+            ):
+                running = (
+                    f" (running {current.version})"
+                    if current is not None and current.version is not None
+                    else ""
+                )
+                raise RuntimeError(
+                    f"Device has reverted the '{component.name}' update{running}"
+                )
+            click.echo(f"Confirming '{component.name}' {component.version}")
+            await session.confirm()

--- a/packages/pyanura-cli/src/pyanura_cli/transceiver_commands.py
+++ b/packages/pyanura-cli/src/pyanura_cli/transceiver_commands.py
@@ -1,18 +1,22 @@
 import asyncio
 import functools
+import io
 import logging
 import sys
 import time
+import zipfile
 from pathlib import Path
 
 import click
 import zeroconf
 
+from anura.dfu import parse_bundle
 from anura.transceiver.client import TransceiverClient
 from anura.transceiver.models import BluetoothAddrLE, ScanNodesReceivedEvent
 from anura.transceiver.proxy_avss_client import ProxyAVSSClient
 from anura.transceiver.transport import USBTransport
 
+from .bundle import TransceiverTarget, apply_bundle
 from .progress import upload_progress
 
 logger = logging.getLogger(__name__)
@@ -252,10 +256,17 @@ async def reset(client: TransceiverClient):
 @click.option(
     "--port", metavar="PORT", default=7645, show_default=True, help="TCP port number"
 )
-@click.option("--file", metavar="FILE", help="Path to firmware image.")
+@click.option(
+    "--file", metavar="FILE", help="Path to firmware image or firmware bundle (.zip)."
+)
 @click.option("--confirm-only", is_flag=True, help="Run only the confirm step.")
 def upgrade(host, port, file, confirm_only):
-    """Upgrade transceiver firmware"""
+    """Upgrade transceiver firmware.
+
+    FILE may be a raw firmware image or a firmware bundle (a .zip with a
+    meta.json manifest). With a bundle, every component in the bundle is
+    applied and confirmed in order.
+    """
 
     if not confirm_only and not file:
         click.echo(
@@ -266,6 +277,23 @@ def upgrade(host, port, file, confirm_only):
 
     if file:
         image = Path(file).read_bytes()
+
+        if not confirm_only and zipfile.is_zipfile(io.BytesIO(image)):
+            try:
+                bundle = parse_bundle(image)
+            except ValueError as ex:
+                click.echo(f"Error: {ex}", err=True)
+                sys.exit(1)
+
+            async def do_bundle():
+                try:
+                    await apply_bundle(TransceiverTarget(host, port), bundle)
+                except Exception as ex:
+                    click.echo(f"Error: {ex}", err=True)
+                    sys.exit(1)
+
+            asyncio.run(do_bundle())
+            return
 
     async def do():
         try:

--- a/src/anura/dfu/__init__.py
+++ b/src/anura/dfu/__init__.py
@@ -1,0 +1,26 @@
+"""Device Firmware Update (DFU) bundles.
+
+A firmware bundle is a zip archive with a ``meta.json`` manifest at the zip
+root describing one flashable image per firmware component ("app", "net"),
+along with target version/build metadata and version constraints on the
+firmware already installed on the device.
+"""
+
+from .bundle import (
+    Bundle,
+    Component,
+    Dependency,
+    parse_bundle,
+    total_dependencies,
+)
+from .version import Version, VersionSet
+
+__all__ = [
+    "Bundle",
+    "Component",
+    "Dependency",
+    "Version",
+    "VersionSet",
+    "parse_bundle",
+    "total_dependencies",
+]

--- a/src/anura/dfu/__init__.py
+++ b/src/anura/dfu/__init__.py
@@ -10,8 +10,11 @@ from .bundle import (
     Bundle,
     Component,
     Dependency,
+    InstalledComponent,
+    UnmetDependency,
     parse_bundle,
     total_dependencies,
+    unmet_dependencies,
 )
 from .version import Version, VersionSet
 
@@ -19,8 +22,11 @@ __all__ = [
     "Bundle",
     "Component",
     "Dependency",
+    "InstalledComponent",
+    "UnmetDependency",
     "Version",
     "VersionSet",
     "parse_bundle",
     "total_dependencies",
+    "unmet_dependencies",
 ]

--- a/src/anura/dfu/bundle.py
+++ b/src/anura/dfu/bundle.py
@@ -1,0 +1,155 @@
+"""
+DFU (Device Firmware Update) bundle data model for Anura devices.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+
+from .version import Version, VersionSet
+
+__all__ = [
+    "Bundle",
+    "Component",
+    "Dependency",
+    "parse_bundle",
+    "total_dependencies",
+]
+
+
+@dataclass
+class Dependency:
+    name: str
+    version: VersionSet
+
+
+@dataclass
+class Component:
+    """A single flashable image inside a bundle"""
+
+    name: str
+    version: Version
+    contents: bytes
+    dependencies: list[Dependency]
+    # Unique build identifier this image was produced from. Bundles that
+    # predate the `target_build` manifest key leave this None and fall back
+    # to numeric version matching.
+    build: str | None = None
+
+    def matches_installed(self, version: Version | None, build: str | None) -> bool:
+        """Whether a device reporting (version, build) is running this component.
+
+        Prefer the build string when both the bundle declares a target build
+        and the device reports one: it is unique even for dev-builds, unlike
+        the numeric version
+        """
+        if self.build is not None and build is not None:
+            return build == self.build
+        return version == self.version
+
+
+@dataclass
+class Bundle:
+    """Bundle: a parsed firmware bundle (provided by parse_bundle)"""
+
+    components: list[Component]
+
+
+def total_dependencies(components: list[Component]) -> list[Dependency]:
+    """Calculate total dependencies of a list of components.
+
+    This routine takes into account that a component may have its dependencies
+    satisfied by or falsified by a preceding component in the list.
+
+    This does not detect if the bundle dependencies as a whole are
+    unsatisfiable. It is up to the DFU routine to check if the device
+    meets the sum total dependencies of the bundle before initiating
+    the DFU operation.
+
+    Raises:
+        ValueError if bundle contains conflicting dependencies
+    """
+    dependencies = defaultdict(lambda: VersionSet(constraints=None))
+    installed_components = {}
+
+    for component in components:
+        for dep in component.dependencies:
+            if dep.name in installed_components:
+                if installed_components[dep.name].version not in dep.version:
+                    raise ValueError("Conflicting component dependencies")
+            else:
+                dependencies[dep.name] = dependencies[dep.name].intersection(
+                    dep.version
+                )
+        installed_components[component.name] = component
+
+    return [Dependency(name, version) for name, version in dependencies.items()]
+
+
+def _parse_bundle_v1(manifest: dict, bundle: zipfile.ZipFile) -> Bundle:
+    components = []
+
+    for name in ["app", "net"]:
+        if name not in manifest:
+            continue
+
+        data = manifest[name]
+
+        version = Version.from_string(data["target_version"])
+        build = data.get("target_build")
+        try:
+            contents = bundle.read(data["path"])
+        except KeyError as e:
+            raise ValueError(
+                f"Bundle is missing component '{name}' image: {data['path']}"
+            ) from e
+        dependencies = []
+
+        if (app_version := data.get("app_version_match")) is not None:
+            dependencies.append(
+                Dependency(name="app", version=VersionSet(constraints=app_version))
+            )
+
+        if (net_version := data.get("net_version_match")) is not None:
+            dependencies.append(
+                Dependency(name="net", version=VersionSet(constraints=net_version))
+            )
+
+        components.append(
+            Component(
+                name=name,
+                version=version,
+                contents=contents,
+                dependencies=dependencies,
+                build=build,
+            )
+        )
+
+    return Bundle(components=components)
+
+
+def parse_bundle(bundle_bytes: bytes, /) -> Bundle:
+    """Parse a firmware bundle."""
+    try:
+        bundle_zip = zipfile.ZipFile(io.BytesIO(bundle_bytes))
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"Bundle is not a valid zip archive: {e}") from e
+
+    with bundle_zip as bundle:
+        try:
+            manifest_bytes = bundle.read("meta.json")
+        except KeyError as e:
+            raise ValueError("Bundle is missing meta.json at the archive root") from e
+        try:
+            manifest = json.loads(manifest_bytes)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Bundle meta.json is not valid JSON: {e}") from e
+
+        version = manifest.get("version")
+        if version == 1:
+            return _parse_bundle_v1(manifest, bundle)
+        raise ValueError(f"Unsupported firmware bundle version: {version!r}")

--- a/src/anura/dfu/bundle.py
+++ b/src/anura/dfu/bundle.py
@@ -8,6 +8,7 @@ import io
 import json
 import zipfile
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 from .version import Version, VersionSet
@@ -16,8 +17,11 @@ __all__ = [
     "Bundle",
     "Component",
     "Dependency",
+    "InstalledComponent",
+    "UnmetDependency",
     "parse_bundle",
     "total_dependencies",
+    "unmet_dependencies",
 ]
 
 
@@ -88,6 +92,59 @@ def total_dependencies(components: list[Component]) -> list[Dependency]:
         installed_components[component.name] = component
 
     return [Dependency(name, version) for name, version in dependencies.items()]
+
+
+@dataclass
+class InstalledComponent:
+    """The firmware a device reports for one component.
+
+    `version` is None when the device is too old to report a version for the
+    component; a dependency on it can then not be verified.
+    """
+
+    version: Version | None
+    build: str | None
+
+
+@dataclass(frozen=True)
+class UnmetDependency:
+    """A dependency the installed firmware does not satisfy."""
+
+    dependency: Dependency
+    # The version the device reports, or None if it reports none.
+    installed: Version | None
+
+    def __str__(self) -> str:
+        if self.installed is None:
+            return (
+                f"requires '{self.dependency.name}' {self.dependency.version}, "
+                f"installed '{self.dependency.name}' version is unknown"
+            )
+        return (
+            f"requires '{self.dependency.name}' {self.dependency.version}, "
+            f"device reports {self.installed}"
+        )
+
+
+def unmet_dependencies(
+    dependencies: Iterable[Dependency],
+    installed: Mapping[str, InstalledComponent],
+) -> list[UnmetDependency]:
+    """Which of `dependencies` the installed firmware does not satisfy.
+
+    An empty list means every dependency is met. A dependency on a component
+    the device reports no version for is unmet: it cannot be verified.
+
+    Callers that want a yes/no answer can use the list's truthiness; callers
+    that report a failure can render each entry for a diagnostic.
+    """
+    unmet = []
+    for dep in dependencies:
+        current = installed.get(dep.name)
+        version = current.version if current is not None else None
+        if version is None or version not in dep.version:
+            unmet.append(UnmetDependency(dependency=dep, installed=version))
+    return unmet
 
 
 def _parse_bundle_v1(manifest: dict, bundle: zipfile.ZipFile) -> Bundle:

--- a/src/anura/dfu/version.py
+++ b/src/anura/dfu/version.py
@@ -1,0 +1,134 @@
+from collections import namedtuple
+from typing import Self
+
+# Inheriting from namedtuple allows us to compare Version instances directly
+# using the standard comparison operators (==, !=, <, <=, >, >=).
+_VersionTuple = namedtuple(
+    "Version",
+    ("major", "minor", "patch", "tweak"),
+    defaults=(0, 0, 0),  # defaults for minor, patch and tweak
+)
+
+
+class Version(_VersionTuple):
+    """
+    Represents a version number with major, minor, patch and version tweak
+    components.
+    """
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}.{self.tweak}"
+
+    @classmethod
+    def from_string(cls, version_str: str) -> Self:
+        """
+        Parse a version string in the format "major.minor.patch.tweak".
+        """
+        parts = version_str.split(".")
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+        tweak = int(parts[3]) if len(parts) > 3 else 0
+
+        return cls(major, minor, patch, tweak)
+
+    @classmethod
+    def from_numeric(cls, version_numeric: int) -> Self:
+        """
+        Parse a version number in the bit-packed format that Anura devices use.
+        """
+        major = (version_numeric >> 24) & 0xFF
+        minor = (version_numeric >> 16) & 0xFF
+        patch = (version_numeric >> 8) & 0xFF
+        tweak = version_numeric & 0xFF
+
+        return cls(major, minor, patch, tweak)
+
+    def as_numeric(self) -> int:
+        """
+        Convert the version to a bit-packed integer format.
+        """
+        return (self.major << 24) | (self.minor << 16) | (self.patch << 8) | self.tweak
+
+
+class VersionSet:
+    """
+    Represents a set of versions. A VersionSet can be used for checking if a
+    Version instance is in the set by doing `Version() in VersionSet()`.
+
+    A VersionSet is defined by a set of constraints. For a `Version` to be
+    considered within a `VersionSet`, it must fulfill all constraints. A
+    VersionSet without constraints, `VersionSet()` is the set of all possible
+    versions.
+
+    The constraints are represented by a list of tuples, where each tuple
+    contains an operator and a Version instance.
+
+    To initialize a VersionSet, provide a string of constraints in the format
+    ">=1.2.3,<2.0.0". The operators can be one of the following: >=, >, <=, <,
+    ==, !=.
+
+    Example:
+    >>> version_set = VersionSet(constraints=">=1.0.0,<2.0.0")
+    >>> version = Version.from_string("1.5.0")
+    >>> version in version_set
+    True
+    """
+
+    def __init__(self, *, constraints: str | None = None):
+        """
+        Parse a version constraint string in the format ">=1.2.3,<2.0.0".
+        """
+        self.constraints: list[tuple[str, Version]] = []
+        if not constraints:
+            return
+        for constraint in constraints.split(","):
+            # NB! The order of the operators matters. Strings starting with "<="
+            # also start with "<". Therefore, check for "<=" before "<".
+            for op in ("==", "!=", "<=", ">=", "<", ">"):
+                if constraint.startswith(op):
+                    self.constraints.append(
+                        (op, Version.from_string(constraint[len(op) :]))
+                    )
+                    break
+            else:
+                raise ValueError(f"Invalid constraint: '{constraint}'")
+
+    def __str__(self) -> str:
+        return ",".join(f"{op}{version}" for op, version in self.constraints)
+
+    def __contains__(self, version: Version) -> bool:
+        """
+        Check if a Version instance satisfies the constraints in the VersionSet.
+        """
+        for operator, constraint_version in self.constraints:
+            if operator == ">=" and not (version >= constraint_version):
+                return False
+            elif operator == ">" and not (version > constraint_version):
+                return False
+            elif operator == "<=" and not (version <= constraint_version):
+                return False
+            elif operator == "<" and not (version < constraint_version):
+                return False
+            elif operator == "==" and not (version == constraint_version):
+                return False
+            elif operator == "!=" and not (version != constraint_version):
+                return False
+        return True
+
+    def intersection(self, other: "VersionSet") -> "VersionSet":
+        """
+        Compute the intersection between this VersionSet and another VersionSet.
+
+        The intersection of two VersionSets contains all versions that satisfy
+        both sets of constraints.
+
+        Args:
+            other: Another VersionSet instance to intersect with.
+
+        Returns:
+            A new VersionSet representing the intersection of both sets.
+        """
+        result = VersionSet()
+        result.constraints = self.constraints + other.constraints
+        return result

--- a/tests/test_dfu_bundle.py
+++ b/tests/test_dfu_bundle.py
@@ -7,10 +7,12 @@ import pytest
 from anura.dfu import (
     Component,
     Dependency,
+    InstalledComponent,
     Version,
     VersionSet,
     parse_bundle,
     total_dependencies,
+    unmet_dependencies,
 )
 
 
@@ -279,3 +281,66 @@ def test_total_dependencies_conflicting():
                 ),
             ]
         )
+
+
+def _installed(**components: str | None) -> dict[str, InstalledComponent]:
+    return {
+        name: InstalledComponent(
+            version=Version.from_string(version) if version else None, build=None
+        )
+        for name, version in components.items()
+    }
+
+
+def test_unmet_dependencies_none_required():
+    assert unmet_dependencies([], _installed(app="2.0.0")) == []
+
+
+def test_unmet_dependencies_all_satisfied():
+    assert (
+        unmet_dependencies(
+            [_make_dependency("app", ">=1.0.0"), _make_dependency("net", ">=3.0.0")],
+            _installed(app="2.0.0", net="3.0.0"),
+        )
+        == []
+    )
+
+
+def test_unmet_dependencies_checks_every_dependency():
+    """A satisfied dependency does not vouch for the ones after it."""
+    unmet = unmet_dependencies(
+        [_make_dependency("app", ">=1.0.0"), _make_dependency("net", ">=4.0.0")],
+        _installed(app="2.0.0", net="3.0.0"),
+    )
+    assert [u.dependency.name for u in unmet] == ["net"]
+    assert unmet[0].installed == Version.from_string("3.0.0")
+    assert str(unmet[0]) == "requires 'net' >=4.0.0.0, device reports 3.0.0.0"
+
+
+def test_unmet_dependencies_reports_all_failures():
+    unmet = unmet_dependencies(
+        [_make_dependency("app", ">=3.0.0"), _make_dependency("net", ">=4.0.0")],
+        _installed(app="2.0.0", net="3.0.0"),
+    )
+    assert [u.dependency.name for u in unmet] == ["app", "net"]
+
+
+def test_unmet_dependencies_unknown_component():
+    """A dependency on a component the device never reported cannot be verified."""
+    unmet = unmet_dependencies(
+        [_make_dependency("bootloader", ">=1.0.0")], _installed(app="2.0.0")
+    )
+    assert [u.dependency.name for u in unmet] == ["bootloader"]
+    assert unmet[0].installed is None
+    assert str(unmet[0]) == (
+        "requires 'bootloader' >=1.0.0.0, installed 'bootloader' version is unknown"
+    )
+
+
+def test_unmet_dependencies_unreported_version():
+    """A component present but without a reported version is equally unverifiable."""
+    unmet = unmet_dependencies(
+        [_make_dependency("net", ">=1.0.0")], _installed(net=None)
+    )
+    assert [u.dependency.name for u in unmet] == ["net"]
+    assert unmet[0].installed is None

--- a/tests/test_dfu_bundle.py
+++ b/tests/test_dfu_bundle.py
@@ -1,0 +1,281 @@
+import io
+import json
+import zipfile
+
+import pytest
+
+from anura.dfu import (
+    Component,
+    Dependency,
+    Version,
+    VersionSet,
+    parse_bundle,
+    total_dependencies,
+)
+
+
+def _make_dependency(name, constraints):
+    return Dependency(name=name, version=VersionSet(constraints=constraints))
+
+
+def _make_component(name, version, dependencies=None):
+    return Component(
+        name=name,
+        version=Version.from_string(version),
+        contents=b"",
+        dependencies=dependencies or [],
+    )
+
+
+def _make_bundle(manifest: dict, files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("meta.json", json.dumps(manifest))
+        for path, contents in files.items():
+            zf.writestr(path, contents)
+    return buffer.getvalue()
+
+
+def test_matches_installed_prefers_build_over_version():
+    """When a target build is declared, match on it and ignore the numeric tweak."""
+    component = Component(
+        name="app",
+        version=Version.from_string("26.5.0"),
+        contents=b"",
+        dependencies=[],
+        build="v26.5.0-29-g569757bd7efa",
+    )
+
+    # Same build, differing numeric tweak (the dev sentinel) — still a match.
+    assert component.matches_installed(
+        Version.from_string("26.5.0.99"), "v26.5.0-29-g569757bd7efa"
+    )
+    # Different build — not the image we flashed.
+    assert not component.matches_installed(Version.from_string("26.5.0.99"), "v26.4.0")
+    # Device too old to report a build string — fall back to numeric version.
+    assert component.matches_installed(Version.from_string("26.5.0"), None)
+    assert not component.matches_installed(Version.from_string("26.5.0.99"), None)
+
+
+def test_matches_installed_falls_back_to_version_without_target_build():
+    """Bundles predating target_build match on exact numeric version."""
+    component = Component(
+        name="app",
+        version=Version.from_string("26.5.0"),
+        contents=b"",
+        dependencies=[],
+    )
+
+    assert component.matches_installed(Version.from_string("26.5.0"), None)
+    assert not component.matches_installed(Version.from_string("26.5.0.99"), None)
+    # The build string is irrelevant when no target build is declared.
+    assert component.matches_installed(Version.from_string("26.5.0"), "anything")
+
+
+def test_parse_bundle_v1():
+    bundle_bytes = _make_bundle(
+        {
+            "version": 1,
+            "app": {
+                "target_version": "26.5.0",
+                "path": "app.bin",
+                "net_version_match": ">=26.0.0",
+            },
+            "net": {"target_version": "26.1.0", "path": "net.bin"},
+        },
+        {"app.bin": b"app firmware", "net.bin": b"net firmware"},
+    )
+
+    bundle = parse_bundle(bundle_bytes)
+
+    # Components come out in app, net order regardless of manifest key order.
+    assert [c.name for c in bundle.components] == ["app", "net"]
+    app, net = bundle.components
+    assert app.version == Version.from_string("26.5.0")
+    assert app.contents == b"app firmware"
+    assert len(app.dependencies) == 1
+    assert app.dependencies[0].name == "net"
+    assert Version.from_string("26.0.0") in app.dependencies[0].version
+    assert Version.from_string("25.9.9") not in app.dependencies[0].version
+    assert net.version == Version.from_string("26.1.0")
+    assert net.contents == b"net firmware"
+    assert net.dependencies == []
+
+
+def test_parse_bundle_reads_target_build():
+    bundle_bytes = _make_bundle(
+        {
+            "version": 1,
+            "app": {
+                "target_version": "26.5.0",
+                "target_build": "v26.5.0-29-g569757bd7efa",
+                "path": "app.bin",
+            },
+        },
+        {"app.bin": b"firmware"},
+    )
+
+    bundle = parse_bundle(bundle_bytes)
+
+    assert len(bundle.components) == 1
+    assert bundle.components[0].build == "v26.5.0-29-g569757bd7efa"
+
+
+def test_parse_bundle_without_target_build_leaves_build_none():
+    bundle_bytes = _make_bundle(
+        {
+            "version": 1,
+            "app": {"target_version": "26.5.0", "path": "app.bin"},
+        },
+        {"app.bin": b"firmware"},
+    )
+
+    bundle = parse_bundle(bundle_bytes)
+
+    assert bundle.components[0].build is None
+
+
+def test_parse_bundle_rejects_non_zip():
+    with pytest.raises(ValueError, match="not a valid zip archive"):
+        parse_bundle(b"raw firmware image")
+
+
+def test_parse_bundle_rejects_missing_manifest():
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("app.bin", b"firmware")
+
+    with pytest.raises(ValueError, match=r"missing meta\.json"):
+        parse_bundle(buffer.getvalue())
+
+
+def test_parse_bundle_rejects_invalid_manifest_json():
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("meta.json", "{not json")
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        parse_bundle(buffer.getvalue())
+
+
+def test_parse_bundle_rejects_unsupported_version():
+    bundle_bytes = _make_bundle({"version": 2}, {})
+
+    with pytest.raises(ValueError, match="Unsupported firmware bundle version"):
+        parse_bundle(bundle_bytes)
+
+
+def test_parse_bundle_rejects_missing_image():
+    bundle_bytes = _make_bundle(
+        {"version": 1, "app": {"target_version": "26.5.0", "path": "app.bin"}},
+        {},
+    )
+
+    with pytest.raises(ValueError, match="missing component 'app' image"):
+        parse_bundle(bundle_bytes)
+
+
+def test_total_dependencies_no_components():
+    """Empty component list should return empty dependencies."""
+    result = total_dependencies([])
+    assert result == []
+
+
+def test_total_dependencies_component_with_no_dependencies():
+    result = total_dependencies([_make_component("app", "1.0")])
+    assert result == []
+
+
+def test_total_dependencies_single_dependency():
+    result = total_dependencies(
+        [
+            _make_component(
+                "app", "2.0", dependencies=[_make_dependency("app", "==1.0")]
+            ),
+        ]
+    )
+    assert len(result) == 1
+    assert result[0].name == "app"
+    assert result[0].version.constraints == VersionSet(constraints="==1.0").constraints
+
+
+def test_total_dependencies_multiple_dependencies():
+    result = total_dependencies(
+        [
+            _make_component(
+                "app", "2.0", dependencies=[_make_dependency("foo", "==1.0")]
+            ),
+            _make_component(
+                "net", "2.0", dependencies=[_make_dependency("bar", "==2.0")]
+            ),
+        ]
+    )
+    assert len(result) == 2
+    assert result[0].name == "foo"
+    assert result[0].version.constraints == VersionSet(constraints="==1.0").constraints
+    assert result[1].name == "bar"
+    assert result[1].version.constraints == VersionSet(constraints="==2.0").constraints
+
+
+def test_total_dependencies_intersection():
+    result = total_dependencies(
+        [
+            _make_component(
+                "app", "2.0", dependencies=[_make_dependency("foo", "!=1.0")]
+            ),
+            _make_component(
+                "net", "2.0", dependencies=[_make_dependency("foo", "!=2.0")]
+            ),
+        ]
+    )
+    assert len(result) == 1
+    assert result[0].name == "foo"
+    # The following assertion is awkward and fragile. VersionSet does not
+    # support the type of equivalence checking we would prefer to make here.
+    assert (
+        result[0].version.constraints
+        == VersionSet(constraints="!=1.0,!=2.0").constraints
+    )
+
+
+def test_total_dependencies_satisfied_by_preceding_component():
+    result = total_dependencies(
+        [
+            _make_component(
+                "app", "2.0", dependencies=[_make_dependency("app", "==1.0")]
+            ),
+            _make_component(
+                "net", "2.0", dependencies=[_make_dependency("app", "==2.0")]
+            ),
+        ]
+    )
+    assert len(result) == 1
+    assert result[0].name == "app"
+    assert result[0].version.constraints == VersionSet(constraints="==1.0").constraints
+
+
+def test_total_dependencies_all_satisfied_within_bundle():
+    result = total_dependencies(
+        [
+            _make_component("app", "1.0", dependencies=[]),
+            _make_component(
+                "app", "2.0", dependencies=[_make_dependency("app", "==1.0")]
+            ),
+            _make_component(
+                "net", "2.0", dependencies=[_make_dependency("app", "==2.0")]
+            ),
+        ]
+    )
+    assert result == []
+
+
+def test_total_dependencies_conflicting():
+    with pytest.raises(ValueError, match="Conflicting component dependencies"):
+        total_dependencies(
+            [
+                _make_component("app", "1.0", dependencies=[]),
+                _make_component(
+                    "net", "2.0", dependencies=[_make_dependency("app", "==2.0")]
+                ),
+            ]
+        )

--- a/tests/test_dfu_version.py
+++ b/tests/test_dfu_version.py
@@ -1,0 +1,100 @@
+import pytest
+
+from anura.dfu import Version, VersionSet
+
+
+def test_version_from_string():
+    assert Version.from_string("1") == Version(1, 0, 0, 0)
+    assert Version.from_string("1.2") == Version(1, 2, 0, 0)
+    assert Version.from_string("1.2.3") == Version(1, 2, 3, 0)
+    assert Version.from_string("1.2.3.4") == Version(1, 2, 3, 4)
+
+
+def test_version_from_numeric():
+    assert Version.from_numeric(0x01020304) == Version(1, 2, 3, 4)
+
+
+def test_version_as_numeric_round_trips():
+    version = Version(1, 2, 3, 4)
+    assert Version.from_numeric(version.as_numeric()) == version
+
+
+def test_version_str():
+    assert str(Version.from_string("1.2.3.4")) == "1.2.3.4"
+    assert str(Version.from_string("1.2")) == "1.2.0.0"
+
+
+def test_empty_version_set_contains_all_versions():
+    version_set = VersionSet()
+
+    assert Version.from_string("0.0.0") in version_set
+    assert Version.from_string("1.0.0") in version_set
+    assert Version.from_string("255.255.255") in version_set
+
+
+def test_single_constraint_greater_than_or_equal():
+    version_set = VersionSet(constraints=">=1.2.3")
+
+    assert Version.from_string("1.2.3") in version_set
+    assert Version.from_string("1.2.4") in version_set
+    assert Version.from_string("2.0.0") in version_set
+    assert Version.from_string("1.2.2") not in version_set
+    assert Version.from_string("1.1.9") not in version_set
+
+
+def test_single_constraint_less_than():
+    version_set = VersionSet(constraints="<2.0.0")
+
+    assert Version.from_string("1.9.9") in version_set
+    assert Version.from_string("1.0.0") in version_set
+    assert Version.from_string("2.0.0") not in version_set
+    assert Version.from_string("2.1.0") not in version_set
+
+
+def test_multiple_constraints():
+    version_set = VersionSet(constraints=">=1.0.0,<2.0.0,!=1.5.0")
+
+    assert Version.from_string("1.0.0") in version_set
+    assert Version.from_string("1.4.9") in version_set
+    assert Version.from_string("1.5.1") in version_set
+    assert Version.from_string("1.5.0") not in version_set
+    assert Version.from_string("0.9.9") not in version_set
+    assert Version.from_string("2.0.0") not in version_set
+
+
+def test_equality_constraint():
+    version_set = VersionSet(constraints="==1.2.3")
+
+    assert Version.from_string("1.2.3") in version_set
+    assert Version.from_string("1.2.4") not in version_set
+    assert Version.from_string("1.2.2") not in version_set
+
+
+def test_not_equal_constraint():
+    version_set = VersionSet(constraints="!=1.2.3")
+
+    assert Version.from_string("1.2.3") not in version_set
+    assert Version.from_string("1.2.4") in version_set
+    assert Version.from_string("1.2.2") in version_set
+
+
+def test_intersection():
+    version_set = VersionSet(constraints=">=1.0.0").intersection(
+        VersionSet(constraints="<2.0.0")
+    )
+
+    assert Version.from_string("1.5.0") in version_set
+    assert Version.from_string("0.9.9") not in version_set
+    assert Version.from_string("2.0.0") not in version_set
+
+
+def test_version_set_str():
+    assert str(VersionSet(constraints=">=1.0.0,<2.0.0")) == ">=1.0.0.0,<2.0.0.0"
+
+
+def test_invalid_constraint_raises_error():
+    with pytest.raises(ValueError, match="Invalid constraint"):
+        VersionSet(constraints="invalid_constraint")
+
+    with pytest.raises(ValueError, match="Invalid constraint"):
+        VersionSet(constraints="2.0.0")


### PR DESCRIPTION
Add anura.dfu with the firmware bundle model: parse_bundle reads a bundle zip (a meta.json manifest plus one image per firmware component) into Bundle/Component/Dependency, with Version and VersionSet for the device version format and dependency constraints.

The CLI "avss upgrade" and "transceiver upgrade" commands now accept a firmware bundle as --file in addition to a raw image.